### PR TITLE
Add update_globals flag for training loops

### DIFF
--- a/artibot/training.py
+++ b/artibot/training.py
@@ -65,6 +65,7 @@ def csv_training_thread(
     *,
     debug_anomaly: bool = False,
     init_event: threading.Event | None = None,
+    update_globals: bool = True,
 ):
     """Train on CSV data in a background thread.
 
@@ -73,6 +74,7 @@ def csv_training_thread(
 
     TODO: add granular ``set_status`` calls for each major step and
     integrate more gating checks.
+    ``update_globals`` controls whether :mod:`artibot.globals` is mutated.
     """
     import traceback
 
@@ -162,7 +164,12 @@ def csv_training_thread(
 
             logging.debug(json.dumps({"event": "status", "msg": G.get_status()}))
             tl, vl = ensemble.train_one_epoch(
-                dl_train, dl_val, train_data, stop_event, features=train_indicators
+                dl_train,
+                dl_val,
+                train_data,
+                stop_event,
+                features=train_indicators,
+                update_globals=update_globals,
             )
 
             status_msg = (
@@ -350,6 +357,7 @@ def csv_training_thread(
                             train_data,
                             stop_event,
                             features=train_indicators,
+                            update_globals=update_globals,
                         )
 
             equity = G.global_equity_curve[-1][1] if G.global_equity_curve else 0.0

--- a/artibot/utils/__init__.py
+++ b/artibot/utils/__init__.py
@@ -156,8 +156,7 @@ def active_feature_dim(hp: IndicatorHyperparams, *, use_ichimoku: bool = False) 
     return dim
 
 
-
-def feature_dim_for(hp: "IndicatorHyperparams") -> int:
+def feature_dim_for(hp: "IndicatorHyperparams") -> int:  # noqa: F811
     """Return the feature dimension implied by *hp*.
 
     • 5 OHLCV bars are always present
@@ -190,4 +189,3 @@ def feature_dim_for(hp: "IndicatorHyperparams") -> int:
 
 
 __all__ = ["rolling_zscore", "feature_dim_for"]
-

--- a/artibot/validation.py
+++ b/artibot/validation.py
@@ -97,6 +97,7 @@ def walk_forward_analysis(csv_path: str, config: dict) -> list[dict]:
             config,
             use_prev_weights=False,
             max_epochs=1,
+            update_globals=False,
         )
         results.append(robust_backtest(ensemble, test))
     return results

--- a/tests/test_feature_dim.py
+++ b/tests/test_feature_dim.py
@@ -32,8 +32,8 @@ sys.modules.setdefault("matplotlib.backends.backend_tkagg", backend)
 # ---------------------------------------------------------------------------
 # Actual tests
 # ---------------------------------------------------------------------------
-from artibot.hyperparams import IndicatorHyperparams
-from artibot.utils import feature_dim_for
+from artibot.hyperparams import IndicatorHyperparams  # noqa: E402
+from artibot.utils import feature_dim_for  # noqa: E402
 
 
 def test_base_dim_all_on():


### PR DESCRIPTION
## Summary
- allow toggling of global metrics during training
- propagate update_globals to background CSV training thread
- disable globals in walk-forward analysis
- fix lint issues

## Testing
- `pytest tests/test_feature_dim.py -q`
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_68533f05d0188324aa1c2e6a3341cc9f