### PR TITLE
Log training/val metrics

### DIFF
--- a/artibot/utils/__init__.py
+++ b/artibot/utils/__init__.py
@@ -34,6 +34,8 @@ class JsonFormatter(logging.Formatter):
             "attn_entropy": getattr(record, "attn_entropy", None),
             "lr": getattr(record, "lr", None),
             "profit_factor": getattr(record, "profit_factor", None),
+            "loss": getattr(record, "loss", None),
+            "val": getattr(record, "val", None),
         }
         return json.dumps(base)
 


### PR DESCRIPTION
## Summary
- show training/validation loss in JsonFormatter output

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68542d1922ec8324a883992aabfeb9e8