### PR TITLE
Fix embed dim not divisible by heads

### DIFF
--- a/artibot/dataset.py
+++ b/artibot/dataset.py
@@ -16,7 +16,7 @@ if "openai" in sys.modules and getattr(sys.modules["openai"], "__spec__", None) 
 
 import torch
 
-from .utils import rolling_zscore, feature_dim_for
+from .utils import rolling_zscore
 from torch.utils.data import Dataset
 
 import artibot.globals as G
@@ -296,8 +296,6 @@ class HourlyDataset(Dataset):
             feats = np.pad(feats, ((0, 0), (0, pad)), constant_values=0.0)
         elif feats.shape[1] > FEATURE_DIM:
             feats = feats[:, :FEATURE_DIM]
-
-        exp_cols = FEATURE_DIM
 
         # ``ta-lib`` leaves the first few rows as NaN which would otherwise
         # propagate through scaling and ultimately make the training loss

--- a/artibot/ensemble.py
+++ b/artibot/ensemble.py
@@ -713,6 +713,7 @@ class EnsembleModel:
 
         # If the live models were built for a different feature count, rebuild
         if self.models[0].input_size != exp_dim:
+            self.rebuild_models(exp_dim)
 
         with torch.no_grad():
             all_probs = []

--- a/artibot/feature_store.py
+++ b/artibot/feature_store.py
@@ -12,13 +12,14 @@ All getters return np.float32.
 
 from __future__ import annotations
 
-# Fixed feature dimension used by training pipelines
-FEATURE_DIM = 17
 import datetime as _dt
 import os
 import duckdb
 import threading
 import numpy as np
+
+# Fixed feature dimension used by training pipelines
+FEATURE_DIM = 17
 
 ###############################################################################
 #  initialise / migrate

--- a/artibot/model.py
+++ b/artibot/model.py
@@ -71,10 +71,20 @@ class TradingModel(nn.Module):
 
         self.input_size = input_size
 
-        self.d_model = input_size
-        self.input_dim = input_size
-        self.pos_encoder = PositionalEncoding(d_model=self.d_model)
         from .hyperparams import TRANSFORMER_HEADS
+
+        self.d_model = (
+            (input_size + TRANSFORMER_HEADS - 1) // TRANSFORMER_HEADS
+        ) * TRANSFORMER_HEADS
+        self.input_dim = input_size
+        if self.d_model != input_size:
+            logger.info(
+                "Adjusting model dim from %d to %d for %d heads",
+                input_size,
+                self.d_model,
+                TRANSFORMER_HEADS,
+            )
+        self.pos_encoder = PositionalEncoding(d_model=self.d_model)
 
         enc_layer = nn.TransformerEncoderLayer(
             d_model=self.d_model,

--- a/artibot/rl.py
+++ b/artibot/rl.py
@@ -75,10 +75,13 @@ class TransformerMetaAgent(nn.Module):
 
         self.state_dim = 6
 
-        d_model = 32
+        from .hyperparams import TRANSFORMER_HEADS
+
+        d_model = (
+            (32 + TRANSFORMER_HEADS - 1) // TRANSFORMER_HEADS
+        ) * TRANSFORMER_HEADS
         self.embed = nn.Linear(self.state_dim, d_model)
         self.pos_enc = PositionalEncoding(d_model)
-        from .hyperparams import TRANSFORMER_HEADS
 
         enc_layer = nn.TransformerEncoderLayer(
             d_model=d_model,

--- a/tests/test_transformer_dim.py
+++ b/tests/test_transformer_dim.py
@@ -1,0 +1,9 @@
+import torch
+from artibot.model import TradingModel
+from artibot.hyperparams import TRANSFORMER_HEADS
+
+
+def test_embed_dim_multiple_of_heads():
+    model = TradingModel(input_size=19)
+    assert model.d_model % TRANSFORMER_HEADS == 0
+    assert model.d_model >= 19


### PR DESCRIPTION
## Summary
- ensure TradingModel rounds up feature dimension to multiple of `TRANSFORMER_HEADS`
- apply the same logic to RL meta agent
- rebuild ensemble models when feature counts change
- remove unused variable in dataset
- reorder imports in feature_store
- add regression test for transformer dimension

## Testing
- `pre-commit run --all-files`
- `pytest -q tests/test_attention.py::test_attention_entropy_range`

------
https://chatgpt.com/codex/tasks/task_e_68556f22bd808324949321ab74632eb5