### PR TITLE
Freeze feature set

### DIFF
--- a/artibot/ensemble.py
+++ b/artibot/ensemble.py
@@ -21,6 +21,7 @@ if "openai" in sys.modules and getattr(sys.modules["openai"], "__spec__", None) 
 
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 import torch.optim as optim
 
 try:
@@ -227,6 +228,16 @@ class EnsembleModel:
         self.grad_accum_steps = grad_accum_steps
         self.total_steps = total_steps
 
+    def _align_features(self, x: torch.Tensor) -> torch.Tensor:
+        """Pad or crop ``x`` to ``self.n_features``."""
+        exp = self.n_features
+        if x.shape[-1] < exp:
+            pad = exp - x.shape[-1]
+            x = F.pad(x, (0, pad))
+        elif x.shape[-1] > exp:
+            x = x[..., :exp]
+        return x
+
     def configure_one_cycle(self, total_steps: int) -> None:
         """Initialise OneCycle schedulers with ``total_steps``."""
         self.total_steps = total_steps
@@ -389,7 +400,7 @@ class EnsembleModel:
                 if accum_counter == 0:
                     for opt in self.optimizers:
                         opt.zero_grad()
-                bx = batch_x.to(self.device).contiguous().clone()
+                bx = self._align_features(batch_x.to(self.device).contiguous())
                 by = batch_y.to(self.device)
 
                 if "device_type" in inspect.signature(autocast).parameters:
@@ -695,7 +706,7 @@ class EnsembleModel:
         losses = []
         with torch.no_grad():
             for bx, by in dl_val:
-                bx = bx.to(self.device)
+                bx = self._align_features(bx.to(self.device))
                 by = by.to(self.device)
                 model_losses = []
                 for mm in self.models:
@@ -712,9 +723,10 @@ class EnsembleModel:
         """Predict a single sample and return ``(index, confidence, None)``."""
 
         with torch.no_grad():
+            x = self._align_features(x.to(self.device))
             outs = []
             for m in self.models:
-                lg, _, _ = m(x.to(self.device))
+                lg, _, _ = m(x)
                 p_ = torch.softmax(lg, dim=1).cpu()
                 outs.append(p_)
             avgp = torch.mean(torch.stack(outs), dim=0)
@@ -737,7 +749,7 @@ class EnsembleModel:
             all_probs = []
             n_ = windows_tensor.shape[0]
             for i in range(0, n_, batch_size):
-                batch = windows_tensor[i : i + batch_size]
+                batch = self._align_features(windows_tensor[i : i + batch_size])
                 batch_probs = []
                 for m in self.models:
                     lg, tpars, _ = m(batch)

--- a/artibot/hyperparams.py
+++ b/artibot/hyperparams.py
@@ -147,9 +147,36 @@ class IndicatorHyperparams:
 # Risk control
 # ---------------------------------------------------------------------------
 RISK_FILTER = {
-    "MIN_SHARPE": -0.5,  # relaxed until model proves itself
-    "MAX_DRAWDOWN": -0.8,
+    "MIN_SHARPE": -1.0,
+    "MAX_DRAWDOWN": -0.90,
 }
 
 # Number of mini-batches for warm-up period
 WARMUP_STEPS = 1000
+
+# Allowed actions for the meta agent once indicator toggles are disabled.
+# Keeping this list in ``hyperparams`` lets other modules share the frozen action
+# space without importing :mod:`artibot.rl` during startup.
+ALLOWED_META_ACTIONS = {
+    "lr",
+    "wd",
+    "d_sma_period",
+    "d_rsi_period",
+    "d_macd_fast",
+    "d_macd_slow",
+    "d_macd_signal",
+    "d_atr_period",
+    "d_vortex_period",
+    "d_cmf_period",
+    "d_ema_period",
+    "d_donchian_period",
+    "d_kijun_period",
+    "d_tenkan_period",
+    "d_displacement",
+    "d_sl",
+    "d_tp",
+    "d_long_frac",
+    "d_short_frac",
+    "d_lr",
+    "d_wd",
+}

--- a/artibot/training.py
+++ b/artibot/training.py
@@ -248,6 +248,7 @@ def csv_training_thread(
 
             if G.global_step >= WARMUP_STEPS and G.global_sharpe > 0:
                 RISK_FILTER["MIN_SHARPE"] = 0.5
+                RISK_FILTER["MAX_DRAWDOWN"] = -0.30
 
             sharpe = G.global_sharpe
             max_dd = G.global_max_drawdown


### PR DESCRIPTION
## Summary
- relax risk filter during warmup and add max drawdown tightening
- freeze meta-agent action space
- stop meta mutations before warmup ends
- crop/pad data in the ensemble instead of rebuilding

## Testing
- `pre-commit run --files artibot/hyperparams.py artibot/training.py artibot/rl.py artibot/ensemble.py`
- `pytest -q` *(fails: 34 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6856a3e56344832484b66aa43352c8e6