### PR TITLE
Fix GUI scaling and restore strategy metrics

### DIFF
--- a/artibot/gui.py
+++ b/artibot/gui.py
@@ -55,6 +55,12 @@ def build_scrollable(master: "tk.Widget") -> "ttk.Frame":
 
             self.inner.bind("<Configure>", _update)
 
+            def _resize(evt):
+                cv.itemconfig(self._win, width=evt.width, height=evt.height)
+                _update()
+
+            cv.bind("<Configure>", _resize)
+
             def _on_wheel(evt):
                 cv.yview_scroll(int(-1 * (evt.delta / 120)), "units")
 
@@ -1217,6 +1223,60 @@ class TradingGUI:
             row=7, column=0, columnspan=2, sticky=tk.W, padx=5, pady=2
         )
 
+        # ------------------------------------------------------------------
+        # current strategy metrics
+        # ------------------------------------------------------------------
+        self.current_sharpe_label = ttk.Label(
+            self.info_frame, text="Sharpe: N/A", font=("Helvetica", 12)
+        )
+        self.current_sharpe_label.grid(row=9, column=0, sticky=tk.W, padx=5, pady=5)
+        self.current_drawdown_label = ttk.Label(
+            self.info_frame, text="Max DD: N/A", font=("Helvetica", 12)
+        )
+        self.current_drawdown_label.grid(row=10, column=0, sticky=tk.W, padx=5, pady=5)
+        self.current_netprofit_label = ttk.Label(
+            self.info_frame, text="Net Profit (%): N/A", font=("Helvetica", 12)
+        )
+        self.current_netprofit_label.grid(row=11, column=0, sticky=tk.W, padx=5, pady=5)
+        self.current_trades_label = ttk.Label(
+            self.info_frame, text="Trades: N/A", font=("Helvetica", 12)
+        )
+        self.current_trades_label.grid(row=12, column=0, sticky=tk.W, padx=5, pady=5)
+        self.current_inactivity_label = ttk.Label(
+            self.info_frame, text="Inactivity Penalty: N/A", font=("Helvetica", 12)
+        )
+        self.current_inactivity_label.grid(
+            row=13, column=0, sticky=tk.W, padx=5, pady=5
+        )
+        self.current_composite_label = ttk.Label(
+            self.info_frame, text="Composite: N/A", font=("Helvetica", 12)
+        )
+        self.current_composite_label.grid(row=14, column=0, sticky=tk.W, padx=5, pady=5)
+        self.current_days_profit_label = ttk.Label(
+            self.info_frame, text="Days in Profit: N/A", font=("Helvetica", 12)
+        )
+        self.current_days_profit_label.grid(
+            row=15, column=0, sticky=tk.W, padx=5, pady=5
+        )
+        self.current_winrate_label = ttk.Label(
+            self.info_frame, text="Win Rate: N/A", font=("Helvetica", 12)
+        )
+        self.current_winrate_label.grid(row=16, column=0, sticky=tk.W, padx=5, pady=5)
+        self.current_profit_factor_label = ttk.Label(
+            self.info_frame, text="Profit Factor: N/A", font=("Helvetica", 12)
+        )
+        self.current_profit_factor_label.grid(
+            row=17, column=0, sticky=tk.W, padx=5, pady=5
+        )
+        self.current_avg_win_label = ttk.Label(
+            self.info_frame, text="Avg Win: N/A", font=("Helvetica", 12)
+        )
+        self.current_avg_win_label.grid(row=18, column=0, sticky=tk.W, padx=5, pady=5)
+        self.current_avg_loss_label = ttk.Label(
+            self.info_frame, text="Avg Loss: N/A", font=("Helvetica", 12)
+        )
+        self.current_avg_loss_label.grid(row=19, column=0, sticky=tk.W, padx=5, pady=5)
+
         self.best_hyper_label = ttk.Label(
             self.info_frame,
             text="Best Hyperparameters:",
@@ -1239,6 +1299,89 @@ class TradingGUI:
             foreground="darkgreen",
         )
         self.best_wd_label.grid(row=6, column=1, sticky=tk.W, padx=5, pady=5)
+
+        # ------------------------------------------------------------------
+        # best strategy metrics
+        # ------------------------------------------------------------------
+        self.best_sharpe_label = ttk.Label(
+            self.info_frame,
+            text="Best Sharpe: N/A",
+            font=("Helvetica", 12),
+            foreground="darkgreen",
+        )
+        self.best_sharpe_label.grid(row=9, column=1, sticky=tk.W, padx=5, pady=5)
+        self.best_drawdown_label = ttk.Label(
+            self.info_frame,
+            text="Best Max DD: N/A",
+            font=("Helvetica", 12),
+            foreground="darkgreen",
+        )
+        self.best_drawdown_label.grid(row=10, column=1, sticky=tk.W, padx=5, pady=5)
+        self.best_netprofit_label = ttk.Label(
+            self.info_frame,
+            text="Best Net Pct: N/A",
+            font=("Helvetica", 12),
+            foreground="darkgreen",
+        )
+        self.best_netprofit_label.grid(row=11, column=1, sticky=tk.W, padx=5, pady=5)
+        self.best_trades_label = ttk.Label(
+            self.info_frame,
+            text="Best Trades: N/A",
+            font=("Helvetica", 12),
+            foreground="darkgreen",
+        )
+        self.best_trades_label.grid(row=12, column=1, sticky=tk.W, padx=5, pady=5)
+        self.best_inactivity_label = ttk.Label(
+            self.info_frame,
+            text="Best Inactivity: N/A",
+            font=("Helvetica", 12),
+            foreground="darkgreen",
+        )
+        self.best_inactivity_label.grid(row=13, column=1, sticky=tk.W, padx=5, pady=5)
+        self.best_composite_label = ttk.Label(
+            self.info_frame,
+            text="Best Composite: N/A",
+            font=("Helvetica", 12),
+            foreground="darkgreen",
+        )
+        self.best_composite_label.grid(row=14, column=1, sticky=tk.W, padx=5, pady=5)
+        self.best_days_profit_label = ttk.Label(
+            self.info_frame,
+            text="Best Days in Profit: N/A",
+            font=("Helvetica", 12),
+            foreground="darkgreen",
+        )
+        self.best_days_profit_label.grid(row=15, column=1, sticky=tk.W, padx=5, pady=5)
+        self.best_winrate_label = ttk.Label(
+            self.info_frame,
+            text="Best Win Rate: N/A",
+            font=("Helvetica", 12),
+            foreground="darkgreen",
+        )
+        self.best_winrate_label.grid(row=16, column=1, sticky=tk.W, padx=5, pady=5)
+        self.best_profit_factor_label = ttk.Label(
+            self.info_frame,
+            text="Best Profit Factor: N/A",
+            font=("Helvetica", 12),
+            foreground="darkgreen",
+        )
+        self.best_profit_factor_label.grid(
+            row=17, column=1, sticky=tk.W, padx=5, pady=5
+        )
+        self.best_avg_win_label = ttk.Label(
+            self.info_frame,
+            text="Best Avg Win: N/A",
+            font=("Helvetica", 12),
+            foreground="darkgreen",
+        )
+        self.best_avg_win_label.grid(row=18, column=1, sticky=tk.W, padx=5, pady=5)
+        self.best_avg_loss_label = ttk.Label(
+            self.info_frame,
+            text="Best Avg Loss: N/A",
+            font=("Helvetica", 12),
+            foreground="darkgreen",
+        )
+        self.best_avg_loss_label.grid(row=19, column=1, sticky=tk.W, padx=5, pady=5)
 
         self.status_var = tk.StringVar()
         self.status_label = ttk.Label(


### PR DESCRIPTION
## Summary
- tweak scrollable widgets so charts resize properly
- add current strategy metrics to sidebar
- add best metrics section
- make charts stretch vertically

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: 39 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6856a4195e8c8324afec615c8f5331bb