### PR TITLE
Guard toggles, clamp lr

### DIFF
--- a/artibot/feature_ingest.py
+++ b/artibot/feature_ingest.py
@@ -78,8 +78,11 @@ def latest_cpi_surprise() -> float:
 
     try:
         rows = requests.get(_MACRO_SRC, timeout=10).json()[:1]
-        actual = float(rows[0]["Actual"])
-        survey = float(rows[0]["Consensus"])
+        try:
+            actual = float(rows[0]["Actual"])
+            survey = float(rows[0]["Consensus"])
+        except KeyError:
+            return 0.0
         return actual - survey
     except Exception as exc:  # pragma: no cover - network
         _LOG.warning("macro fetch failed: %s", exc)

--- a/artibot/hyperparams.py
+++ b/artibot/hyperparams.py
@@ -151,6 +151,11 @@ RISK_FILTER = {
     "MAX_DRAWDOWN": -0.90,
 }
 
+# floor for optimiser learning-rate (can be overridden via ``master_config.json``)
+LR_MIN = float(_CONFIG.get("LR_MIN", 1e-6))
+# optional upper clamp when meta-agent mutates LR
+LR_MAX = float(_CONFIG.get("LR_MAX", 5e-4))
+
 # Number of mini-batches for warm-up period
 WARMUP_STEPS = 1000
 
@@ -183,5 +188,6 @@ ALLOWED_META_ACTIONS = {
 
 
 def mutate_lr(old_lr: float, delta: float) -> float:
-    """Return learning-rate clamped within [1e-5, 5e-4]."""
-    return max(1e-5, min(5e-4, old_lr + delta))
+    """Return a learning-rate within ``[LR_MIN, LR_MAX]``."""
+
+    return max(LR_MIN, min(LR_MAX, old_lr + delta))

--- a/artibot/rl.py
+++ b/artibot/rl.py
@@ -6,7 +6,7 @@ import artibot.globals as G
 import artibot.hyperparams as hyperparams
 from .hyperparams import HyperParams, IndicatorHyperparams
 from .model import PositionalEncoding
-from .utils import active_feature_dim
+from .feature_store import FEATURE_DIM
 
 import random as _random
 import numpy as np
@@ -579,9 +579,9 @@ def meta_control_loop(
             act = filtered
             with G.model_lock:
                 agent.apply_action(hp, indicator_hp, act)
-                new_dim = active_feature_dim(indicator_hp, use_ichimoku=hp.use_ichimoku)
-                if new_dim != ensemble.models[0].input_dim:
-                    ensemble.rebuild_models(new_dim)
+                # models stay fixed at FEATURE_DIM; missing indicators are padded
+                if ensemble.models[0].input_dim != FEATURE_DIM:
+                    ensemble.rebuild_models(FEATURE_DIM)
 
             G.status_sleep("Meta agent sleeping", "", interval)
 


### PR DESCRIPTION
## Summary
- clamp optimizer learning rates via new LR_MIN constant
- adjust risk filter logic for early trade count
- keep models fixed at FEATURE_DIM to stop rebuilds
- trap missing macro data

## Testing
- `pre-commit run --files artibot/hyperparams.py artibot/ensemble.py artibot/rl.py artibot/feature_ingest.py`
- `pytest -q` *(fails: TypeError, AssertionError, ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_68593df30bdc83249da83ca275d5839d