### PR TITLE
Freeze feature set after warm‑up

### DIFF
--- a/artibot/ensemble.py
+++ b/artibot/ensemble.py
@@ -76,7 +76,7 @@ def reject_if_risky(
     max_drawdown = float(thresholds.get("MAX_DRAWDOWN", -0.30))
 
     # Early-stage models get a looser gate until trade count builds up
-    if G.global_num_trades < 200:
+    if G.global_num_trades < 1000:
         return sharpe <= 0.0 and max_dd <= -0.40
 
     if entropy < min_entropy:

--- a/artibot/hyperparams.py
+++ b/artibot/hyperparams.py
@@ -152,7 +152,7 @@ RISK_FILTER = {
 }
 
 # floor for optimiser learning-rate (can be overridden via ``master_config.json``)
-LR_MIN = float(_CONFIG.get("LR_MIN", 1e-6))
+LR_MIN = float(_CONFIG.get("LR_MIN", 1e-5))
 # optional upper clamp when meta-agent mutates LR
 LR_MAX = float(_CONFIG.get("LR_MAX", 5e-4))
 
@@ -188,6 +188,10 @@ ALLOWED_META_ACTIONS = {
 
 
 def mutate_lr(old_lr: float, delta: float) -> float:
-    """Return a learning-rate within ``[LR_MIN, LR_MAX]``."""
+    """Return a learning-rate within ``[LR_MIN, LR_MAX]`` with ±20% cap."""
 
-    return max(LR_MIN, min(LR_MAX, old_lr + delta))
+    new_lr = old_lr + delta
+    rel_min = old_lr * 0.8
+    rel_max = old_lr * 1.2
+    clamped = max(rel_min, min(rel_max, new_lr))
+    return max(LR_MIN, min(LR_MAX, clamped))

--- a/artibot/rl.py
+++ b/artibot/rl.py
@@ -252,9 +252,9 @@ class MetaTransformerRL:
         self.prev_logprob = logp.detach()
         self.prev_action_idx = action_idx
         filtered = {}
-        warm = G.get_warmup_step() < hyperparams.WARMUP_STEPS
+        freeze = G.get_warmup_step() >= hyperparams.WARMUP_STEPS
         for action_name, val in act.items():
-            if action_name.startswith("toggle_") and warm:
+            if action_name.startswith("toggle_") and freeze:
                 continue
             if action_name not in hyperparams.ALLOWED_META_ACTIONS:
                 continue
@@ -351,9 +351,9 @@ class MetaTransformerRL:
             logging.info("FEATURE_IMPORTANCE %s %.3f", k, prob)
 
         filtered = {}
-        warm = G.get_warmup_step() < hyperparams.WARMUP_STEPS
+        freeze = G.get_warmup_step() >= hyperparams.WARMUP_STEPS
         for action_name, val in act.items():
-            if action_name.startswith("toggle_") and warm:
+            if action_name.startswith("toggle_") and freeze:
                 continue
             if action_name not in hyperparams.ALLOWED_META_ACTIONS:
                 continue
@@ -569,9 +569,9 @@ def meta_control_loop(
 
             act, logp, val_s = agent.pick_action(state)
             filtered = {}
-            warm = G.get_warmup_step() < hyperparams.WARMUP_STEPS
+            freeze = G.get_warmup_step() >= hyperparams.WARMUP_STEPS
             for action_name, val in act.items():
-                if action_name.startswith("toggle_") and warm:
+                if action_name.startswith("toggle_") and freeze:
                     continue
                 if action_name not in hyperparams.ALLOWED_META_ACTIONS:
                     continue

--- a/tests/test_feature_freeze.py
+++ b/tests/test_feature_freeze.py
@@ -1,0 +1,26 @@
+import types
+import artibot.globals as G
+from artibot.hyperparams import HyperParams, IndicatorHyperparams, WARMUP_STEPS
+from artibot.rl import MetaTransformerRL
+
+
+def test_toggles_ignored_after_warmup(monkeypatch):
+    monkeypatch.setattr(G, "get_warmup_step", lambda: WARMUP_STEPS)
+
+    class DummyOpt:
+        def __init__(self) -> None:
+            self.param_groups = [{"lr": 0.01, "weight_decay": 0.0}]
+
+    class DummyEnsemble:
+        def __init__(self) -> None:
+            self.optimizers = [DummyOpt()]
+            self.indicator_hparams = IndicatorHyperparams()
+
+    ens = DummyEnsemble()
+    agent = MetaTransformerRL(ens)
+    hp = HyperParams(indicator_hp=ens.indicator_hparams)
+    before = ens.indicator_hparams.use_rsi
+
+    agent.apply_action(hp, ens.indicator_hparams, {"toggle_rsi": 1})
+
+    assert ens.indicator_hparams.use_rsi == before


### PR DESCRIPTION
## Summary
- clamp learning rates with +/-20% relative step and new LR_MIN
- delay risk filter until 1k trades
- ignore toggle mutations once warm-up completes
- add regression test for feature freeze logic

## Testing
- `pre-commit run --all-files`
- `pytest tests/test_feature_freeze.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685961c177288324a213e2f56ad3f1ca