### PR TITLE
Stabilize training with lr clamp and feature freezing

### DIFF
--- a/artibot/dataset.py
+++ b/artibot/dataset.py
@@ -289,7 +289,12 @@ class HourlyDataset(Dataset):
 
         feats = np.column_stack(cols)
 
-        from .feature_store import FEATURE_DIM
+        from .feature_store import FEATURE_DIM, freeze_feature_dim
+        from . import hyperparams as _hp
+        import artibot.globals as _g
+
+        if _hp.should_freeze_features(_g.get_warmup_step()):
+            freeze_feature_dim(feats.shape[1])
 
         if feats.shape[1] < FEATURE_DIM:
             pad = FEATURE_DIM - feats.shape[1]

--- a/artibot/feature_store.py
+++ b/artibot/feature_store.py
@@ -20,6 +20,17 @@ import numpy as np
 
 # Fixed feature dimension used by training pipelines
 FEATURE_DIM = 17
+_FROZEN_DIM = None
+
+
+def freeze_feature_dim(dim: int) -> None:
+    """Persist ``dim`` as the global feature dimension once warm-up ends."""
+
+    global FEATURE_DIM, _FROZEN_DIM
+    if _FROZEN_DIM is None:
+        _FROZEN_DIM = dim
+        FEATURE_DIM = dim
+
 
 ###############################################################################
 #  initialise / migrate

--- a/artibot/rl.py
+++ b/artibot/rl.py
@@ -252,9 +252,13 @@ class MetaTransformerRL:
         self.prev_logprob = logp.detach()
         self.prev_action_idx = action_idx
         filtered = {}
-        freeze = G.get_warmup_step() >= hyperparams.WARMUP_STEPS
+        freeze = hyperparams.should_freeze_features(G.get_warmup_step())
         for action_name, val in act.items():
-            if action_name.startswith("toggle_") and freeze:
+            if freeze and (
+                action_name.startswith("toggle_")
+                or action_name.endswith("_period")
+                or action_name.endswith("_frac")
+            ):
                 continue
             if action_name not in hyperparams.ALLOWED_META_ACTIONS:
                 continue
@@ -351,9 +355,13 @@ class MetaTransformerRL:
             logging.info("FEATURE_IMPORTANCE %s %.3f", k, prob)
 
         filtered = {}
-        freeze = G.get_warmup_step() >= hyperparams.WARMUP_STEPS
+        freeze = hyperparams.should_freeze_features(G.get_warmup_step())
         for action_name, val in act.items():
-            if action_name.startswith("toggle_") and freeze:
+            if freeze and (
+                action_name.startswith("toggle_")
+                or action_name.endswith("_period")
+                or action_name.endswith("_frac")
+            ):
                 continue
             if action_name not in hyperparams.ALLOWED_META_ACTIONS:
                 continue
@@ -569,9 +577,13 @@ def meta_control_loop(
 
             act, logp, val_s = agent.pick_action(state)
             filtered = {}
-            freeze = G.get_warmup_step() >= hyperparams.WARMUP_STEPS
+            freeze = hyperparams.should_freeze_features(G.get_warmup_step())
             for action_name, val in act.items():
-                if action_name.startswith("toggle_") and freeze:
+                if freeze and (
+                    action_name.startswith("toggle_")
+                    or action_name.endswith("_period")
+                    or action_name.endswith("_frac")
+                ):
                     continue
                 if action_name not in hyperparams.ALLOWED_META_ACTIONS:
                     continue

--- a/tests/test_lr_clamp.py
+++ b/tests/test_lr_clamp.py
@@ -1,0 +1,13 @@
+import artibot.hyperparams as hp
+
+
+def test_mutate_lr_bounds():
+    start = 1e-4
+    big_delta = start * 0.5
+    assert hp.mutate_lr(start, big_delta) <= hp.LR_MAX
+    assert hp.mutate_lr(start, -big_delta) >= hp.LR_MIN
+    up = hp.mutate_lr(start, big_delta)
+    assert up - start <= start * hp.LR_FN_MAX_DELTA + 1e-12
+    down = hp.mutate_lr(start, -big_delta)
+    assert start - down <= start * hp.LR_FN_MAX_DELTA + 1e-12
+    assert hp.mutate_lr(hp.LR_MIN, -1.0) == hp.LR_MIN

--- a/tests/test_risk_gate.py
+++ b/tests/test_risk_gate.py
@@ -1,0 +1,7 @@
+import artibot.globals as G
+from artibot.ensemble import reject_if_risky
+
+
+def test_early_stage_gate_relaxed(monkeypatch):
+    monkeypatch.setattr(G, "global_num_trades", 500)
+    assert reject_if_risky(sharpe=0.2, max_dd=-0.5, entropy=0.5) is False


### PR DESCRIPTION
## Summary
- clamp LR mutations in hyperparams
- freeze indicator feature dimension after warm-up
- filter toggle and period actions once frozen
- clamp optimizer LR/WD using helper
- add regression tests for LR clamp, feature freeze and risk gate

## Testing
- `pre-commit run --all-files`
- `pytest -q tests/test_lr_clamp.py tests/test_feature_freeze.py tests/test_risk_gate.py`

------
https://chatgpt.com/codex/tasks/task_e_685978c791848324933a30b7ba456f92