### PR TITLE
Unify feature dimension constant

### DIFF
--- a/artibot/feature_store.py
+++ b/artibot/feature_store.py
@@ -20,6 +20,8 @@ import numpy as np
 import json
 import pathlib
 
+from artibot.dataset import FEATURE_DIMENSION
+
 _STORE = pathlib.Path(".feature_dim.json")
 
 
@@ -34,7 +36,7 @@ def safe_divide(a, b, default=0.0):
 
 
 # Fixed feature dimension used by training pipelines
-FEATURE_DIM = 17
+FEATURE_DIM = FEATURE_DIMENSION
 _FROZEN_DIM = None
 
 

--- a/artibot/model.py
+++ b/artibot/model.py
@@ -7,7 +7,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 
-from .dataset import TradeParams
+from .dataset import FEATURE_DIMENSION, TradeParams
 import artibot.globals as G
 from .utils import attention_entropy
 
@@ -66,12 +66,12 @@ class TradingModel(nn.Module):
         dropout: float = 0.4,
     ) -> None:
         super().__init__()
-        if input_size != 16:
+        if input_size != FEATURE_DIMENSION:
             raise ValueError("Feature dimension mismatch")
         self.input_size = input_size
         self.hidden_size = hidden_size
 
-        self.d_model = 16
+        self.d_model = FEATURE_DIMENSION
         self.input_dim = input_size
         self.pos_encoder = PositionalEncoding(d_model=self.d_model)
 

--- a/run_artibot.py
+++ b/run_artibot.py
@@ -155,7 +155,7 @@ def main() -> None:
 
     from artibot.utils import setup_logging, get_device
     from artibot.ensemble import EnsembleModel
-    from artibot.dataset import HourlyDataset, load_csv_hourly
+    from artibot.dataset import FEATURE_DIMENSION, HourlyDataset, load_csv_hourly
     from artibot.hyperparams import HyperParams, IndicatorHyperparams
     from artibot.training import (
         PhemexConnector,


### PR DESCRIPTION
## Summary
- centralize feature size as `FEATURE_DIMENSION` in `dataset.py`
- update checks in dataset to use the new constant
- reference the constant from model and feature store
- import it in `run_artibot.py`

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: Feature dimension mismatch and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_685ab86a241483248624e696c6450faa