### PR TITLE
Improve feature validation and trimming

### DIFF
--- a/artibot/feature_store.py
+++ b/artibot/feature_store.py
@@ -90,6 +90,20 @@ def _con() -> duckdb.DuckDBPyConnection:
     return _get_con()
 
 
+def generate_features(data) -> np.ndarray:
+    """Return ``data`` as an ``np.ndarray`` trimmed to ``FEATURE_DIMENSION``."""
+
+    features = np.asarray(data, dtype=np.float32)
+    if features.ndim == 1:
+        features = features.reshape(1, -1)
+
+    # Ensure feature count is integer
+    if features.shape[1] != int(FEATURE_DIMENSION):
+        features = features[:, : int(FEATURE_DIMENSION)]
+
+    return features
+
+
 # ---------------------------------------------------------------------------
 # table creation + idempotent migrations
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- expand `HourlyDataset` init to include `expected_features`
- add detailed feature dimension debug info
- gracefully trim mismatched feature arrays
- ensure feature dimensions in feature store

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: 29 failed, 78 passed)*

------
https://chatgpt.com/codex/tasks/task_e_685ac416823c83249435a459b57e1372