### PR TITLE
Handle list inputs in backtest and validation

### DIFF
--- a/artibot/backtest.py
+++ b/artibot/backtest.py
@@ -196,6 +196,10 @@ def robust_backtest(ensemble, data_full, indicators=None):
         Optional dictionary with precomputed ``sma``, ``rsi`` and ``macd``
         arrays. When ``None`` (default), they are derived on the fly.
     """
+    # Ensure ``data_full`` is a NumPy array for shape checks
+    if isinstance(data_full, list):
+        data_full = np.array(data_full)
+
     # [FIXED]# log incoming feature dimensions
     print(f"[BACKTEST] Input feature dimension: {data_full.shape}")
     if data_full.shape[1] != 16:  # Match your FEATURE_DIMENSION

--- a/artibot/dataset.py
+++ b/artibot/dataset.py
@@ -264,6 +264,8 @@ class HourlyDataset(Dataset):
         features = generate_fixed_features(
             data_np, self.hp, use_ichimoku=self.use_ichimoku
         )
+        if isinstance(features, list):
+            features = np.array(features)
         print(f"[DEBUG] Actual feature count: {features.shape[1]}")
         # [FIX]# clean NaN/Inf values
         features = clean_features(features, replace_value=0.0)
@@ -463,6 +465,11 @@ class HourlyDataset(Dataset):
         labels = labels[mask]
 
         windows = np.nan_to_num(windows)
+
+        if isinstance(windows, list):
+            windows = np.array(windows)
+        if isinstance(labels, list):
+            labels = np.array(labels)
 
         return windows.astype(np.float32), labels.astype(np.int64)
 

--- a/artibot/validation.py
+++ b/artibot/validation.py
@@ -100,6 +100,8 @@ def walk_forward_analysis(csv_path: str, config: dict) -> list[dict]:
             update_globals=False,
         )
         # [FIXED]# debug logging for test set
+        if not isinstance(test, np.ndarray):
+            test = np.array(test)
         print(f"[VALIDATION] Test data shape: {test.shape}")
         print(f"[VALIDATION] Feature sample: {test.iloc[0, :16]}")
         results.append(robust_backtest(ensemble, test))


### PR DESCRIPTION
## Summary
- ensure `data_full` and `test` are converted to numpy arrays before shape checks
- safeguard dataset preprocessing when lists are passed in

## Testing
- `pre-commit run --all-files`
- `pytest tests/test_dataset.py::test_feature_cleaning -q`

------
https://chatgpt.com/codex/tasks/task_e_6862b73a324083248f8c71434789df4a