### PR TITLE
Centralize feature dimension config

### DIFF
--- a/artibot/__init__.py
+++ b/artibot/__init__.py
@@ -9,6 +9,10 @@ the installer ran once on first launch.
 from .environment import ensure_dependencies
 
 ensure_dependencies()  # run the installer once at import time
+from config import FEATURE_CONFIG
+
+print(f"[INIT] System configured for {FEATURE_CONFIG['expected_features']} features")
+print(f"[INIT] Feature columns: {', '.join(FEATURE_CONFIG['feature_columns'])}")
 
 try:
     from screeninfo import get_monitors

--- a/artibot/backtest.py
+++ b/artibot/backtest.py
@@ -202,12 +202,15 @@ def robust_backtest(ensemble, data_full, indicators=None):
 
     # [FIXED]# log incoming feature dimensions
     print(f"[BACKTEST] Input feature dimension: {data_full.shape}")
-    if data_full.shape[1] != 16:  # Match your FEATURE_DIMENSION
+    from config import FEATURE_CONFIG
+
+    expected = FEATURE_CONFIG["expected_features"]
+    if data_full.shape[1] != expected:
         print("[WARN] Backtest data dimension mismatch! Adjusting…")
-        if data_full.shape[1] > 16:
-            data_full = data_full[:, :16]
+        if data_full.shape[1] > expected:
+            data_full = data_full[:, :expected]
         else:
-            padding = np.zeros((data_full.shape[0], 16 - data_full.shape[1]))
+            padding = np.zeros((data_full.shape[0], expected - data_full.shape[1]))
             data_full = np.hstack([data_full, padding])
         print(f"[INFO] Adjusted backtest data shape: {data_full.shape}")
     if len(data_full) < 24:

--- a/artibot/dataset.py
+++ b/artibot/dataset.py
@@ -27,8 +27,9 @@ from torch.utils.data import Dataset
 import artibot.globals as G
 import logging
 from .hyperparams import IndicatorHyperparams
+from config import FEATURE_CONFIG
 
-FEATURE_DIMENSION = 16
+FEATURE_DIMENSION = FEATURE_CONFIG["expected_features"]
 
 
 ###############################################################################
@@ -110,6 +111,12 @@ def load_csv_hourly(csv_path: str) -> list[list[float]]:
     cols = ["unix", "open", "high", "low", "close", "volume_btc"]
     arr = df[cols].to_numpy(dtype=float)
     arr = arr[np.isfinite(arr).all(axis=1)]
+    arr = np.nan_to_num(
+        arr,
+        nan=0.0,
+        posinf=np.finfo(np.float32).max,
+        neginf=np.finfo(np.float32).min,
+    )
 
     return arr[np.argsort(arr[:, 0])].tolist()
 

--- a/artibot/feature_store.py
+++ b/artibot/feature_store.py
@@ -20,7 +20,7 @@ import numpy as np
 import json
 import pathlib
 
-from artibot.dataset import FEATURE_DIMENSION
+from config import FEATURE_CONFIG
 
 _STORE = pathlib.Path(".feature_dim.json")
 
@@ -36,7 +36,7 @@ def safe_divide(a, b, default=0.0):
 
 
 # Fixed feature dimension used by training pipelines
-FEATURE_DIM = FEATURE_DIMENSION
+FEATURE_DIM = FEATURE_CONFIG["expected_features"]
 _FROZEN_DIM = None
 
 
@@ -98,8 +98,9 @@ def generate_features(data) -> np.ndarray:
         features = features.reshape(1, -1)
 
     # Ensure feature count is integer
-    if features.shape[1] != int(FEATURE_DIMENSION):
-        features = features[:, : int(FEATURE_DIMENSION)]
+    expected = FEATURE_CONFIG["expected_features"]
+    if features.shape[1] != int(expected):
+        features = features[:, : int(expected)]
 
     return features
 

--- a/artibot/model.py
+++ b/artibot/model.py
@@ -7,9 +7,12 @@ import numpy as np
 import torch
 import torch.nn as nn
 
-from .dataset import FEATURE_DIMENSION, TradeParams
 import artibot.globals as G
+from config import FEATURE_CONFIG
+from .dataset import TradeParams
 from .utils import attention_entropy
+
+FEATURE_DIMENSION = FEATURE_CONFIG["expected_features"]
 
 logger = logging.getLogger(__name__)
 

--- a/config.py
+++ b/config.py
@@ -1,0 +1,22 @@
+FEATURE_CONFIG = {
+    "expected_features": 16,
+    "feature_columns": [
+        "open",
+        "high",
+        "low",
+        "close",
+        "volume",
+        "sma_10",
+        "sma_50",
+        "rsi",
+        "macd",
+        "boll_upper",
+        "boll_lower",
+        "vwap",
+        "obv",
+        "stoch_k",
+        "stoch_d",
+        "atr",
+    ],
+}
+

--- a/data_loader.py
+++ b/data_loader.py
@@ -1,0 +1,30 @@
+from config import FEATURE_CONFIG
+import numpy as np
+
+
+def load_and_clean_data(path):
+    """Load CSV data and ensure correct feature dimensions."""
+    from artibot.dataset import load_csv_hourly
+
+    data = np.array(load_csv_hourly(path), dtype=float)
+    if data.size == 0:
+        return data
+
+    if data.shape[1] != FEATURE_CONFIG["expected_features"]:
+        if data.shape[1] > FEATURE_CONFIG["expected_features"]:
+            data = data[:, : FEATURE_CONFIG["expected_features"]]
+        else:
+            padding = np.zeros(
+                (data.shape[0], FEATURE_CONFIG["expected_features"] - data.shape[1])
+            )
+            data = np.hstack([data, padding])
+
+    data = np.nan_to_num(
+        data,
+        nan=0.0,
+        posinf=np.finfo(np.float32).max,
+        neginf=np.finfo(np.float32).min,
+    )
+
+    return data
+


### PR DESCRIPTION
## Summary
- add `FEATURE_CONFIG` with expected columns
- print feature info during package init
- adjust dataset and feature store to use the new config
- handle feature padding/trimming in the ensemble
- clean NaN/Inf values during CSV load
- align validation logic with configured feature count
- add helper `load_and_clean_data`

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6862c98d7f3083249035dfc50234eabd