### PR TITLE
Implement stricter feature validation

### DIFF
--- a/artibot/dataset.py
+++ b/artibot/dataset.py
@@ -21,6 +21,7 @@ from .utils import (
     feature_version_hash,
     validate_features,
     clean_features,
+    enforce_feature_dim,
     validate_feature_dimension,
     zero_disabled,
     feature_mask_for,
@@ -222,6 +223,35 @@ def generate_fixed_features(
     return features
 
 
+def build_features(
+    data_np: np.ndarray,
+    hp: IndicatorHyperparams,
+    *,
+    use_ichimoku: bool = False,
+    expected_features: int = FEATURE_DIMENSION,
+    logger: logging.Logger | None = None,
+) -> np.ndarray:
+    """Return normalised feature matrix for ``data_np``."""
+
+    feats = generate_fixed_features(data_np, hp, use_ichimoku=use_ichimoku)
+    if isinstance(feats, list):
+        feats = np.array(feats)
+    feats = clean_features(feats, replace_value=0.0)
+    feats = enforce_feature_dim(feats, expected_features)
+    feats = validate_feature_dimension(
+        feats, expected_features, logger or logging.getLogger("build_features")
+    )
+    validate_features(feats, expected_features)
+    feats = np.nan_to_num(feats)
+    imputer = KNNImputer(n_neighbors=5)
+    feats = imputer.fit_transform(feats)
+    mask = feature_mask_for(hp, use_ichimoku=use_ichimoku)
+    feats = zero_disabled(feats, mask)
+    feats = rolling_zscore(feats, window=50, mask=mask)
+    feats = zero_disabled(feats, mask)
+    return feats.astype(np.float32)
+
+
 def preprocess_features(
     data_np: np.ndarray,
     hp: IndicatorHyperparams,
@@ -242,10 +272,11 @@ def preprocess_features(
     if isinstance(features, list):
         features = np.array(features)
     features = clean_features(features, replace_value=0.0)
+    features = enforce_feature_dim(features, expected_features)
     features = validate_feature_dimension(
         features, expected_features, logger or logging.getLogger("preprocess")
     )
-    validate_features(features)
+    validate_features(features, expected_features)
 
     features = np.nan_to_num(features)
 

--- a/data_loader.py
+++ b/data_loader.py
@@ -1,6 +1,7 @@
 from config import FEATURE_CONFIG
 import numpy as np
 from artibot.feature_manager import sanitize_features
+from artibot.utils import enforce_feature_dim, validate_features
 
 
 def load_and_clean_data(path):
@@ -12,10 +13,12 @@ def load_and_clean_data(path):
         return data
 
     if data.shape[1] != FEATURE_CONFIG["expected_features"]:
-        raise ValueError(
-            f"CSV has {data.shape[1]} features, expected {FEATURE_CONFIG['expected_features']}"
-        )
+        data = enforce_feature_dim(data, FEATURE_CONFIG["expected_features"])
 
     data = sanitize_features(data)
+    validate_features(data)
+    assert not np.isnan(data).any(), "NaN detected in features"
+    assert not np.isinf(data).any(), "Inf detected in features"
+    assert data.any(axis=0).all(), "Zero-feature detected"
 
     return data


### PR DESCRIPTION
## Summary
- add `DimensionError` exception and `enforce_feature_dim` helper
- harden `validate_features` and export new helpers
- provide `build_features` for a unified preprocessing flow
- pad backtest data and validate dimensions
- add strict sanity checks when loading data

## Testing
- `pre-commit run --files artibot/utils/__init__.py artibot/dataset.py data_loader.py artibot/backtest.py`
- `pytest tests/test_feature_validation.py::test_validate_feature_dimension_no_change -q --no-heavy`

------
https://chatgpt.com/codex/tasks/task_e_68633bdd90008324bc7f6b162676a220