### PR TITLE
Add feature masks for strategy A

### DIFF
--- a/artibot/utils/__init__.py
+++ b/artibot/utils/__init__.py
@@ -289,14 +289,15 @@ def validate_features(
         raise DimensionError("Inf detected in features")
 
     if enabled_mask is not None:
-        mask = np.asarray(enabled_mask, dtype=bool)
-        if mask.size != features.shape[-1]:
+        active = np.asarray(enabled_mask, dtype=bool)
+        if active.size != features.shape[-1]:
             raise DimensionError("Feature mask size mismatch")
-        if not features[:, mask].any(axis=0).all():
-            raise DimensionError("Zero-feature detected")
+        zero_cols = (np.ptp(features, axis=0) == 0) & active
     else:
-        if not features.any(axis=0).all():
-            raise DimensionError("Zero-feature detected")
+        zero_cols = np.ptp(features, axis=0) == 0
+
+    if zero_cols.any():
+        raise DimensionError("Zero-feature detected")
 
 
 def validate_feature_dimension(

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -110,7 +110,7 @@ def test_backtest_with_precomputed_features(monkeypatch):
         for i in range(30)
     ]
     ens = DummyEnsemble()
-    indicators = compute_indicators(data, ens.indicator_hparams, with_scaled=True)
+    indicators = compute_indicators(data, ens.indicator_hparams)
     result_pre = robust_backtest(ens, data, indicators=indicators)
     result_std = robust_backtest(ens, data)
     assert result_pre["net_pct"] == pytest.approx(result_std["net_pct"], rel=5e-3)

--- a/tests/test_csv_workers.py
+++ b/tests/test_csv_workers.py
@@ -1,6 +1,7 @@
 import os
 import threading
 
+import numpy as np
 import torch
 
 from artibot.training import csv_training_thread
@@ -24,7 +25,7 @@ def test_csv_thread_uses_config(monkeypatch):
     monkeypatch.setattr("torch.utils.data.random_split", lambda ds, lens: (ds, ds))
     monkeypatch.setattr(
         "artibot.training.compute_indicators",
-        lambda *a, **k: {"sma": [], "rsi": [], "macd": [], "scaled": []},
+        lambda *a, **k: (np.zeros((0, 16), dtype=np.float32), np.ones(16, dtype=bool)),
     )
 
     ens = EnsembleModel(device=torch.device("cpu"), n_models=1)
@@ -58,7 +59,7 @@ def test_persistent_workers_enabled(monkeypatch):
     monkeypatch.setattr("torch.utils.data.random_split", lambda ds, lens: (ds, ds))
     monkeypatch.setattr(
         "artibot.training.compute_indicators",
-        lambda *a, **k: {"sma": [], "rsi": [], "macd": [], "scaled": []},
+        lambda *a, **k: (np.zeros((0, 16), dtype=np.float32), np.ones(16, dtype=bool)),
     )
 
     ens = EnsembleModel(device=torch.device("cpu"), n_models=1)

--- a/tests/test_logging_update.py
+++ b/tests/test_logging_update.py
@@ -1,5 +1,6 @@
 import logging
 import types
+import numpy as np
 
 import pytest
 import torch
@@ -97,7 +98,10 @@ def test_epoch_logging_includes_net_pct_and_lr(monkeypatch, caplog):
     monkeypatch.setattr("torch.utils.data.random_split", lambda ds, lens: (ds, ds))
     monkeypatch.setattr(
         "artibot.training.compute_indicators",
-        lambda *a, **k: {"sma": [], "rsi": [], "macd": [], "scaled": []},
+        lambda *a, **k: {
+            "features": np.zeros((0, 16), dtype=np.float32),
+            "mask": np.ones(16, dtype=bool),
+        },
     )
 
     class DummyDS:


### PR DESCRIPTION
## Summary
- return feature matrix and mask in `compute_indicators`
- use the mask in dataset preprocessing
- improve zero‑column checks
- adjust tests for new indicator helper

## Testing
- `pre-commit run --all-files`
- `pytest tests/test_dataset.py::test_feature_cleaning -q`

------
https://chatgpt.com/codex/tasks/task_e_6863bb2a1ae8832487342ac066cceced