### PR TITLE
Refactor feature validation with mask

### DIFF
--- a/artibot/__init__.py
+++ b/artibot/__init__.py
@@ -10,8 +10,9 @@ from .environment import ensure_dependencies
 
 ensure_dependencies()  # run the installer once at import time
 from config import FEATURE_CONFIG
+from .constants import FEATURE_DIMENSION
 
-print(f"[INIT] System configured for {FEATURE_CONFIG['expected_features']} features")
+print(f"[INIT] System configured for {FEATURE_DIMENSION} features")
 print(f"[INIT] Feature columns: {', '.join(FEATURE_CONFIG['feature_columns'])}")
 
 try:

--- a/artibot/constants.py
+++ b/artibot/constants.py
@@ -1,0 +1,6 @@
+"""Package-wide constants used across Artibot."""
+
+FEATURE_DIMENSION = 16
+
+__all__ = ["FEATURE_DIMENSION"]
+

--- a/artibot/dataset.py
+++ b/artibot/dataset.py
@@ -32,9 +32,7 @@ from torch.utils.data import Dataset
 import artibot.globals as G
 import logging
 from .hyperparams import IndicatorHyperparams
-from config import FEATURE_CONFIG
-
-FEATURE_DIMENSION = FEATURE_CONFIG["expected_features"]
+from .constants import FEATURE_DIMENSION
 
 
 ###############################################################################
@@ -242,7 +240,7 @@ def build_features(
         feats, expected_features, logger or logging.getLogger("build_features")
     )
     mask = feature_mask_for(hp, use_ichimoku=use_ichimoku)
-    validate_features(feats, expected_features, enabled_mask=mask)
+    validate_features(feats, enabled_mask=mask)
     feats = np.nan_to_num(feats)
     imputer = KNNImputer(n_neighbors=5)
     feats[:, mask] = imputer.fit_transform(feats[:, mask])
@@ -270,10 +268,10 @@ def preprocess_features(
 
     from .backtest import compute_indicators
 
-    ind = compute_indicators(data_np, hp, use_ichimoku=use_ichimoku)
-    features = ind["features"]
+    ind = compute_indicators(data_np, hp, use_ichimoku=use_ichimoku, with_scaled=True)
+    features = ind["scaled"]
     mask = ind["mask"]
-    validate_features(features, expected_features=len(mask), enabled_mask=mask)
+    validate_features(features, enabled_mask=mask)
 
     features = clean_features(features, replace_value=0.0)
     features = enforce_feature_dim(features, len(mask))

--- a/artibot/ensemble.py
+++ b/artibot/ensemble.py
@@ -41,7 +41,7 @@ from .utils import zero_disabled
 import artibot.globals as G
 from .metrics import compute_yearly_stats, compute_monthly_stats
 from .model import TradingModel
-from config import FEATURE_CONFIG
+from .constants import FEATURE_DIMENSION
 from .feature_manager import validate_and_align_features
 
 
@@ -170,7 +170,7 @@ class EnsembleModel(nn.Module):
         )
         self.hp = HyperParams(indicator_hp=self.indicator_hparams)
 
-        fixed_dim = FEATURE_CONFIG["expected_features"]
+        fixed_dim = FEATURE_DIMENSION
         self.expected_features = fixed_dim
         self.n_features = fixed_dim
 

--- a/artibot/feature_manager.py
+++ b/artibot/feature_manager.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import numpy as np
 import torch
 
-from config import FEATURE_CONFIG
+from .constants import FEATURE_DIMENSION
 
 
 class FeatureDimensionError(Exception):
@@ -46,7 +46,7 @@ def validate_and_align_features(fn):
         if not isinstance(x, (torch.Tensor, np.ndarray)):
             return fn(*args, **kwargs)
 
-        expected = FEATURE_CONFIG["expected_features"]
+        expected = FEATURE_DIMENSION
         current = x.shape[-1]
         if current != expected:
             raise FeatureDimensionError(f"Expected {expected} features, got {current}")

--- a/artibot/feature_store.py
+++ b/artibot/feature_store.py
@@ -20,7 +20,7 @@ import numpy as np
 import json
 import pathlib
 
-from config import FEATURE_CONFIG
+from .constants import FEATURE_DIMENSION
 
 _STORE = pathlib.Path(".feature_dim.json")
 
@@ -36,7 +36,7 @@ def safe_divide(a, b, default=0.0):
 
 
 # Fixed feature dimension used by training pipelines
-FEATURE_DIM = FEATURE_CONFIG["expected_features"]
+FEATURE_DIM = FEATURE_DIMENSION
 _FROZEN_DIM = None
 
 
@@ -98,7 +98,7 @@ def generate_features(data) -> np.ndarray:
         features = features.reshape(1, -1)
 
     # Ensure feature count is integer
-    expected = FEATURE_CONFIG["expected_features"]
+    expected = FEATURE_DIMENSION
     if features.shape[1] != int(expected):
         features = features[:, : int(expected)]
 

--- a/artibot/features.py
+++ b/artibot/features.py
@@ -4,6 +4,7 @@ import logging
 import pandas as pd
 import numpy as np
 
+from .constants import FEATURE_DIMENSION
 from config import FEATURE_CONFIG
 from .utils import validate_feature_dimension
 
@@ -12,7 +13,7 @@ class FeatureEngineer:
     """Calculate technical indicator features with strict dimension checks."""
 
     def __init__(self) -> None:
-        self.expected_features = int(FEATURE_CONFIG["expected_features"])
+        self.expected_features = FEATURE_DIMENSION
         self.feature_columns = FEATURE_CONFIG.get("feature_columns", [])
         self.logger = logging.getLogger("FeatureEngineer")
 

--- a/artibot/model.py
+++ b/artibot/model.py
@@ -8,11 +8,10 @@ import torch
 import torch.nn as nn
 
 import artibot.globals as G
-from config import FEATURE_CONFIG
+from .constants import FEATURE_DIMENSION
 from .dataset import TradeParams
 from .utils import attention_entropy
 
-FEATURE_DIMENSION = FEATURE_CONFIG["expected_features"]
 
 logger = logging.getLogger(__name__)
 

--- a/artibot/validation.py
+++ b/artibot/validation.py
@@ -9,7 +9,7 @@ import numpy as np
 import pandas as pd
 import logging
 
-from config import FEATURE_CONFIG
+from .constants import FEATURE_DIMENSION
 
 from .feature_manager import align_features, sanitize_features, FeatureDimensionError
 
@@ -29,9 +29,9 @@ MONTH_SECONDS = 30 * 24 * 3600
 def validate_dataset(dataset: np.ndarray) -> np.ndarray:
     """Return sanitized ``dataset`` or raise :class:`FeatureDimensionError`."""
 
-    if dataset.shape[1] != FEATURE_CONFIG["expected_features"]:
+    if dataset.shape[1] != FEATURE_DIMENSION:
         raise FeatureDimensionError(
-            f"Dataset has {dataset.shape[1]} features, expected {FEATURE_CONFIG['expected_features']}"
+            f"Dataset has {dataset.shape[1]} features, expected {FEATURE_DIMENSION}"
         )
 
     sanitized = sanitize_features(dataset)
@@ -75,7 +75,7 @@ def walk_forward_analysis(csv_path: str, config: dict) -> list[dict]:
     if not data:
         return []
     raw_data = np.array(data, dtype=float)
-    aligned_data = align_features(raw_data, FEATURE_CONFIG["expected_features"])
+    aligned_data = align_features(raw_data, FEATURE_DIMENSION)
     data = sanitize_features(aligned_data)
     device = get_device()
 
@@ -129,13 +129,13 @@ def walk_forward_analysis(csv_path: str, config: dict) -> list[dict]:
             test = np.array(test)
         print(f"[VALIDATION] Test data shape: {test.shape}")
         if hasattr(test, "iloc"):
-            sample = test.iloc[0, : FEATURE_CONFIG["expected_features"]]
+            sample = test.iloc[0, :FEATURE_DIMENSION]
         else:
-            sample = test[0, : FEATURE_CONFIG["expected_features"]]
+            sample = test[0, :FEATURE_DIMENSION]
         print(f"[VALIDATION] Feature sample: {sample}")
-        if test.shape[1] != FEATURE_CONFIG["expected_features"]:
+        if test.shape[1] != FEATURE_DIMENSION:
             raise FeatureDimensionError(
-                f"Expected {FEATURE_CONFIG['expected_features']} features, got {test.shape[1]}"
+                f"Expected {FEATURE_DIMENSION} features, got {test.shape[1]}"
             )
         results.append(robust_backtest(ensemble, test))
     return results

--- a/data_loader.py
+++ b/data_loader.py
@@ -1,4 +1,4 @@
-from config import FEATURE_CONFIG
+from artibot.constants import FEATURE_DIMENSION
 import numpy as np
 from artibot.feature_manager import sanitize_features
 from artibot.utils import enforce_feature_dim, validate_features, feature_mask_for
@@ -13,8 +13,8 @@ def load_and_clean_data(path):
     if data.size == 0:
         return data
 
-    if data.shape[1] != FEATURE_CONFIG["expected_features"]:
-        data = enforce_feature_dim(data, FEATURE_CONFIG["expected_features"])
+    if data.shape[1] != FEATURE_DIMENSION:
+        data = enforce_feature_dim(data, FEATURE_DIMENSION)
 
     data = sanitize_features(data)
     mask = feature_mask_for(IndicatorHyperparams())

--- a/tests/test_csv_workers.py
+++ b/tests/test_csv_workers.py
@@ -25,7 +25,10 @@ def test_csv_thread_uses_config(monkeypatch):
     monkeypatch.setattr("torch.utils.data.random_split", lambda ds, lens: (ds, ds))
     monkeypatch.setattr(
         "artibot.training.compute_indicators",
-        lambda *a, **k: (np.zeros((0, 16), dtype=np.float32), np.ones(16, dtype=bool)),
+        lambda *a, **k: {
+            "scaled": np.zeros((0, 16), dtype=np.float32),
+            "mask": np.ones(16, dtype=bool),
+        },
     )
 
     ens = EnsembleModel(device=torch.device("cpu"), n_models=1)
@@ -59,7 +62,10 @@ def test_persistent_workers_enabled(monkeypatch):
     monkeypatch.setattr("torch.utils.data.random_split", lambda ds, lens: (ds, ds))
     monkeypatch.setattr(
         "artibot.training.compute_indicators",
-        lambda *a, **k: (np.zeros((0, 16), dtype=np.float32), np.ones(16, dtype=bool)),
+        lambda *a, **k: {
+            "scaled": np.zeros((0, 16), dtype=np.float32),
+            "mask": np.ones(16, dtype=bool),
+        },
     )
 
     ens = EnsembleModel(device=torch.device("cpu"), n_models=1)

--- a/tests/test_feature_validation.py
+++ b/tests/test_feature_validation.py
@@ -40,3 +40,11 @@ def test_validate_features_zero_enabled():
     mask = feature_mask_for(hp)
     with pytest.raises(DimensionError):
         validate_features(arr, enabled_mask=mask)
+
+
+def test_zero_variance_ignored_on_disabled_cols():
+    feats = np.random.randn(100, 16).astype(np.float32)
+    mask = np.ones(16, dtype=np.uint8)
+    mask[8:] = 0
+    feats[:, 8:] = 0.0
+    validate_features(feats, enabled_mask=mask)

--- a/tests/test_logging_update.py
+++ b/tests/test_logging_update.py
@@ -99,7 +99,7 @@ def test_epoch_logging_includes_net_pct_and_lr(monkeypatch, caplog):
     monkeypatch.setattr(
         "artibot.training.compute_indicators",
         lambda *a, **k: {
-            "features": np.zeros((0, 16), dtype=np.float32),
+            "scaled": np.zeros((0, 16), dtype=np.float32),
             "mask": np.ones(16, dtype=bool),
         },
     )


### PR DESCRIPTION
## Summary
- centralise `FEATURE_DIMENSION` constant
- update feature validators to use boolean mask
- compute indicators with mask-enabled helper
- propagate mask through dataset and backtest
- fix tests for new API

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_6863dce4c7488324899d82f278b69939