### PR TITLE
Fix numpy ptp call and drop expected_features argument

### DIFF
--- a/artibot/constants.py
+++ b/artibot/constants.py
@@ -3,4 +3,3 @@
 FEATURE_DIMENSION = 16
 
 __all__ = ["FEATURE_DIMENSION"]
-

--- a/artibot/dataset.py
+++ b/artibot/dataset.py
@@ -226,7 +226,6 @@ def build_features(
     hp: IndicatorHyperparams,
     *,
     use_ichimoku: bool = False,
-    expected_features: int = FEATURE_DIMENSION,
     logger: logging.Logger | None = None,
 ) -> np.ndarray:
     """Return normalised feature matrix for ``data_np``."""
@@ -235,9 +234,9 @@ def build_features(
     if isinstance(feats, list):
         feats = np.array(feats)
     feats = clean_features(feats, replace_value=0.0)
-    feats = enforce_feature_dim(feats, expected_features)
+    feats = enforce_feature_dim(feats, FEATURE_DIMENSION)
     feats = validate_feature_dimension(
-        feats, expected_features, logger or logging.getLogger("build_features")
+        feats, FEATURE_DIMENSION, logger or logging.getLogger("build_features")
     )
     mask = feature_mask_for(hp, use_ichimoku=use_ichimoku)
     validate_features(feats, enabled_mask=mask)
@@ -256,14 +255,13 @@ def preprocess_features(
     seq_len: int,
     *,
     use_ichimoku: bool = False,
-    expected_features: int = FEATURE_DIMENSION,
     drop_last: bool = False,
     logger: logging.Logger | None = None,
 ) -> tuple[np.ndarray, np.ndarray]:
     """Return ``(features, windows)`` for ``data_np``.
 
     Disabled indicators are replaced with ``0.0`` so the returned arrays
-    always have ``expected_features`` columns.
+    always have ``FEATURE_DIMENSION`` columns.
     """
 
     from .backtest import compute_indicators
@@ -317,7 +315,6 @@ class HourlyDataset(Dataset):
         train_mode: bool = True,
         rebalance: bool = True,
         use_ichimoku: bool = False,
-        expected_features: int = FEATURE_DIMENSION,
     ) -> None:
         self.data = data
         self.seq_len = seq_len
@@ -333,9 +330,9 @@ class HourlyDataset(Dataset):
         self.use_cmf = indicator_hparams.use_cmf
         self.cmf_period = indicator_hparams.cmf_period
         self.use_ichimoku = use_ichimoku
-        self.expected_features = int(expected_features)
+        self.expected_features = FEATURE_DIMENSION
         self.logger = logging.getLogger("dataset")
-        print(f"[INIT] Expected features type: {type(expected_features)}")
+        print(f"[INIT] Expected features type: {type(FEATURE_DIMENSION)}")
         sample_np = np.array(self.data[: min(len(self.data), 100)], dtype=float)
         check_feats = generate_fixed_features(
             sample_np, indicator_hparams, use_ichimoku=use_ichimoku
@@ -353,7 +350,6 @@ class HourlyDataset(Dataset):
             self.hp,
             self.seq_len,
             use_ichimoku=self.use_ichimoku,
-            expected_features=self.expected_features,
             drop_last=True,
             logger=self.logger,
         )

--- a/artibot/utils/__init__.py
+++ b/artibot/utils/__init__.py
@@ -278,7 +278,7 @@ def validate_features(feat: np.ndarray, enabled_mask: np.ndarray) -> None:
     if not np.isfinite(active).all():
         raise DimensionError("NaN or Inf detected in features")
 
-    if (active.ptp(axis=0) == 0).any():
+    if (np.ptp(active, axis=0) == 0).any():
         raise DimensionError("Zero-feature detected")
 
 

--- a/tests/test_feature_validation.py
+++ b/tests/test_feature_validation.py
@@ -48,3 +48,9 @@ def test_zero_variance_ignored_on_disabled_cols():
     mask[8:] = 0
     feats[:, 8:] = 0.0
     validate_features(feats, enabled_mask=mask)
+
+
+def test_validate_features_numpy2_dummy_mask():
+    arr = np.random.randn(10, 16).astype(float)
+    mask = np.ones(16, dtype=bool)
+    validate_features(arr, enabled_mask=mask)


### PR DESCRIPTION
## Summary
- use `np.ptp` in `validate_features`
- rely on `FEATURE_DIMENSION` constant in dataset helpers
- remove deprecated `expected_features` parameter
- adjust feature validation tests

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: 32 failed, 81 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6863e7f80dd4832492f839c82d6eeabc