### PR TITLE
Handle zeroed features in validate_features

### DIFF
--- a/artibot/utils/__init__.py
+++ b/artibot/utils/__init__.py
@@ -284,10 +284,14 @@ def validate_features(feat: np.ndarray, enabled_mask: np.ndarray | None = None) 
         raise DimensionError("NaN or Inf detected in features")
 
     ranges = np.ptp(active, axis=0)
-    if (ranges > 0).all():
+    has_var = ranges > 0
+    if (~has_var).any():
+        for idx, var in enumerate(has_var):
+            if not var and not np.allclose(active[:, idx], 0.0):
+                raise DimensionError("Zero variance feature detected")
+    if has_var.any():
         return
-    if not (ranges > 0).any():
-        raise DimensionError("All active features have zero variance")
+    raise DimensionError("All active features have zero variance")
 
 
 def validate_feature_dimension(

--- a/tests/test_feature_validation.py
+++ b/tests/test_feature_validation.py
@@ -59,7 +59,8 @@ def test_validate_features_numpy2_dummy_mask():
 def test_zero_variance_partial_columns():
     arr = np.ones((5, 2), dtype=float)
     arr[:, 1] = np.arange(5)
-    validate_features(arr, enabled_mask=np.array([True, True]))
+    with pytest.raises(DimensionError):
+        validate_features(arr, enabled_mask=np.array([True, True]))
 
 
 def test_zero_variance_all_columns():


### PR DESCRIPTION
## Summary
- allow zero-variance columns when completely zeroed in `validate_features`
- update feature validation test expectation

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: 29 failed, 89 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6864043acf8883248c5797b73538ea1b