### PR TITLE
Add runtime indicator toggles

### DIFF
--- a/artibot/dataset.py
+++ b/artibot/dataset.py
@@ -329,7 +329,18 @@ class HourlyDataset(Dataset):
             raise ValueError(
                 f"Feature engineering produces {check_feats.shape[1]} features, expected {self.expected_features}."
             )
+        self.mask = feature_mask_for(indicator_hparams, use_ichimoku=use_ichimoku)
         self.samples, self.labels = self.preprocess()
+
+    def apply_feature_mask(
+        self, hp: IndicatorHyperparams, *, use_ichimoku: bool | None = None
+    ) -> None:
+        """Zero out features based on ``hp`` without rebuilding the dataset."""
+
+        if use_ichimoku is not None:
+            self.use_ichimoku = use_ichimoku
+        self.mask = feature_mask_for(hp, use_ichimoku=self.use_ichimoku)
+        self.samples = zero_disabled(self.samples, self.mask)
 
     def preprocess(self):
         data_np = np.array(self.data, dtype=float)

--- a/artibot/rl.py
+++ b/artibot/rl.py
@@ -624,6 +624,8 @@ def meta_control_loop(
             act = filtered
             with G.model_lock:
                 agent.apply_action(hp, indicator_hp, act)
+                if dataset is not None:
+                    dataset.apply_feature_mask(indicator_hp)
                 # models stay fixed at FEATURE_DIM; missing indicators are padded
                 if ensemble.models[0].input_dim != FEATURE_DIM:
                     ensemble.rebuild_models(FEATURE_DIM)


### PR DESCRIPTION
## Summary
- let the meta agent zero out dataset features when toggling indicators
- expose `apply_feature_mask` on `HourlyDataset`

## Testing
- `pre-commit run --all-files`
- `NO_HEAVY=1 pytest tests/test_validation.py::test_gate_nuclear_key -q`

------
https://chatgpt.com/codex/tasks/task_e_68646ef169b88324af19209cacc33fbc