### PR TITLE
Fix NaN handling in indicator features

### DIFF
--- a/artibot/backtest.py
+++ b/artibot/backtest.py
@@ -75,7 +75,7 @@ def compute_indicators(
 
     def add_feat(col: np.ndarray, active: bool) -> None:
         nonlocal cols, mask
-        cols.append(np.nan_to_num(col))
+        cols.append(np.nan_to_num(col, nan=0.0, posinf=0.0, neginf=0.0))
         mask.append(1 if active else 0)
 
     for c in raw[:, 1:6].T:
@@ -152,6 +152,7 @@ def compute_indicators(
     add_feat(tenkan, bool(use_ichimoku or getattr(indicator_hp, "use_tenkan", False)))
 
     feats = np.column_stack(cols).astype(np.float32)
+    feats = np.nan_to_num(feats, nan=0.0, posinf=0.0, neginf=0.0)
     mask_arr = np.asarray(mask, dtype=np.uint8)
 
     # ensure constant feature dimension
@@ -176,6 +177,7 @@ def compute_indicators(
         tmp = zero_disabled(tmp, active)
         tmp = rolling_zscore(tmp, window=50, mask=active)
         tmp = zero_disabled(tmp, active)
+        tmp = np.nan_to_num(tmp, nan=0.0, posinf=0.0, neginf=0.0)
         result["scaled"] = tmp.astype(np.float32)
 
     return result
@@ -311,7 +313,7 @@ def robust_backtest(
         else sliding_window_view(extd, (24, extd.shape[1])).squeeze()
     )
     windows = np.clip(windows, -50.0, 50.0)
-    windows = np.nan_to_num(windows)
+    windows = np.nan_to_num(windows, nan=0.0, posinf=0.0, neginf=0.0)
     assert (
         windows.shape[2] == mask.size
     ), f"Expected {mask.size} features, got {windows.shape[2]}"

--- a/artibot/feature_manager.py
+++ b/artibot/feature_manager.py
@@ -18,14 +18,14 @@ def sanitize_features(x: torch.Tensor | np.ndarray) -> torch.Tensor | np.ndarray
         return torch.nan_to_num(
             x,
             nan=0.0,
-            posinf=torch.finfo(x.dtype).max,
-            neginf=torch.finfo(x.dtype).min,
+            posinf=0.0,
+            neginf=0.0,
         )
     return np.nan_to_num(
         x,
         nan=0.0,
-        posinf=np.finfo(x.dtype).max,
-        neginf=np.finfo(x.dtype).min,
+        posinf=0.0,
+        neginf=0.0,
     )
 
 

--- a/artibot/utils/__init__.py
+++ b/artibot/utils/__init__.py
@@ -128,7 +128,7 @@ def rolling_zscore(
         df = (df - roll_mean) / roll_std
     scaled = df.to_numpy(dtype=float)
     scaled = np.clip(scaled, -50.0, 50.0)
-    return np.nan_to_num(scaled).astype(np.float32)
+    return np.nan_to_num(scaled, nan=0.0, posinf=0.0, neginf=0.0).astype(np.float32)
 
 
 def feature_dim_for(indicators: "IndicatorHyperparams") -> int:


### PR DESCRIPTION
## Summary
- sanitize columns in `compute_indicators`
- clean NaN/Inf from dataset feature generation
- sanitize tensors in `feature_manager`
- ensure utils' normalisation returns finite values

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: 37 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68649097c7748324bd2abd8670977f31