### PR TITLE
Fix feature padding in preview

### DIFF
--- a/artibot/dataset.py
+++ b/artibot/dataset.py
@@ -212,7 +212,7 @@ def generate_fixed_features(
 
     # Sanitise invalid values before validation
     if np.isnan(feats).any() or np.isinf(feats).any():
-        print("[WARN] NaN/Inf detected in raw features!")
+        logging.debug("Raw features contained NaN/Inf – cleaned")
     features = np.nan_to_num(feats.astype(np.float32), nan=0.0, posinf=0.0, neginf=0.0)
 
     features = validate_feature_dimension(

--- a/artibot/training.py
+++ b/artibot/training.py
@@ -14,6 +14,7 @@ import os
 from .dataset import HourlyDataset, trailing_sma
 from .ensemble import reject_if_risky
 from .backtest import robust_backtest, compute_indicators
+from .feature_manager import enforce_feature_dim
 
 import sys
 import json
@@ -313,6 +314,8 @@ def csv_training_thread(
                         ]
                     )
                 ext = np.array(ext, dtype=np.float32)
+                # Pad preview tensor to match model input width
+                ext = enforce_feature_dim(ext, expected=16)
                 seq_t = (
                     torch.tensor(ext, dtype=torch.float32)
                     .unsqueeze(0)


### PR DESCRIPTION
## Summary
- prevent 8/16 mismatch in quick preview by padding features
- quiet NaN/Inf spam in dataset

## Testing
- `pre-commit run --all-files`
- `pytest -q tests/test_backtest.py tests/test_feature_dim.py`


------
https://chatgpt.com/codex/tasks/task_e_6864f15f84e883249193395dc5503674