### PR TITLE
Adjust class weights for cross entropy

### DIFF
--- a/artibot/ensemble.py
+++ b/artibot/ensemble.py
@@ -204,7 +204,7 @@ class EnsembleModel(nn.Module):
             for m in self.models
         ]
         self.criterion = nn.CrossEntropyLoss(
-            weight=torch.tensor([3.0, 3.0, 0.2]).to(device)
+            weight=torch.tensor([2.0, 2.0, 1.0]).to(device)
         )
         self.mse_loss_fn = nn.MSELoss()
         amp_on = device.type == "cuda"


### PR DESCRIPTION
## Summary
- tweak class weights in ensemble CrossEntropyLoss from `[3.0, 3.0, 0.2]` to `[2.0, 2.0, 1.0]`

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: 45 failed, 74 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6865abe1e1908324b51a0ac084c3dac8