### PR TITLE
Add reward flags and risk filter to startup dialog

### DIFF
--- a/artibot/ensemble.py
+++ b/artibot/ensemble.py
@@ -67,6 +67,9 @@ def reject_if_risky(
 ) -> bool:
     """Return ``True`` when metrics breach the configured risk limits."""
 
+    if not G.is_risk_filter_enabled():
+        return False
+
     if thresholds is None:
         try:  # lazy import avoids circular dependency
             from .bot_app import CONFIG

--- a/artibot/globals.py
+++ b/artibot/globals.py
@@ -146,6 +146,7 @@ use_sharpe_term = True
 use_drawdown_term = True
 use_trade_term = True
 use_profit_days_term = True
+risk_filter_enabled = True
 
 ###############################################################################
 # GPT Memories (unchanged)
@@ -321,6 +322,21 @@ def is_nuclear_key_enabled() -> bool:
     """Return ``True`` when the nuclear key gate is active."""
     with state_lock:
         return nuclear_key_enabled
+
+
+def set_risk_filter_enabled(enabled: bool) -> None:
+    """Toggle the training risk filter."""
+    global risk_filter_enabled
+    with state_lock:
+        risk_filter_enabled = enabled
+    status = "ENABLED" if enabled else "DISABLED"
+    logging.info("RISK_FILTER_%s", status)
+
+
+def is_risk_filter_enabled() -> bool:
+    """Return ``True`` when the risk filter is active."""
+    with state_lock:
+        return risk_filter_enabled
 
 
 def set_live_weights_updated(value: bool) -> None:

--- a/artibot/gui.py
+++ b/artibot/gui.py
@@ -167,6 +167,12 @@ def startup_options_dialog(
             "use_live": bool(defaults.get("use_live", False)),
             "use_prev_weights": bool(defaults.get("use_prev_weights", True)),
             "threads": int(defaults.get("threads", os.cpu_count() or 1)),
+            "use_net_term": bool(defaults.get("use_net_term", True)),
+            "use_sharpe_term": bool(defaults.get("use_sharpe_term", True)),
+            "use_drawdown_term": bool(defaults.get("use_drawdown_term", True)),
+            "use_trade_term": bool(defaults.get("use_trade_term", True)),
+            "use_profit_days_term": bool(defaults.get("use_profit_days_term", True)),
+            "risk_filter": bool(defaults.get("risk_filter", True)),
         }
 
     root.title("Startup Options")
@@ -177,6 +183,14 @@ def startup_options_dialog(
     )
     threads_max = os.cpu_count() or 1
     threads_var = tk_module.IntVar(value=int(defaults.get("threads", threads_max)))
+    risk_var = tk_module.BooleanVar(value=bool(defaults.get("risk_filter", True)))
+    net_var = tk_module.BooleanVar(value=bool(defaults.get("use_net_term", True)))
+    sharpe_var = tk_module.BooleanVar(value=bool(defaults.get("use_sharpe_term", True)))
+    dd_var = tk_module.BooleanVar(value=bool(defaults.get("use_drawdown_term", True)))
+    trade_var = tk_module.BooleanVar(value=bool(defaults.get("use_trade_term", True)))
+    days_var = tk_module.BooleanVar(
+        value=bool(defaults.get("use_profit_days_term", True))
+    )
 
     tk_module.Checkbutton(
         root, text="Skip GDELT sentiment download", variable=skip_var
@@ -187,6 +201,15 @@ def startup_options_dialog(
     tk_module.Checkbutton(
         root, text="Load previous weights", variable=weights_var
     ).pack(anchor="w")
+    tk_module.Checkbutton(root, text="Enable risk filter", variable=risk_var).pack(
+        anchor="w"
+    )
+    tk_module.Label(root, text="Reward terms:").pack(anchor="w")
+    tk_module.Checkbutton(root, text="Net%", variable=net_var).pack(anchor="w")
+    tk_module.Checkbutton(root, text="Sharpe", variable=sharpe_var).pack(anchor="w")
+    tk_module.Checkbutton(root, text="Drawdown", variable=dd_var).pack(anchor="w")
+    tk_module.Checkbutton(root, text="Trades", variable=trade_var).pack(anchor="w")
+    tk_module.Checkbutton(root, text="Profit Days", variable=days_var).pack(anchor="w")
     tk_module.Label(root, text="CPU threads:").pack(anchor="w")
     tk_module.Spinbox(
         root,
@@ -201,6 +224,12 @@ def startup_options_dialog(
         result["use_live"] = live_var.get()
         result["use_prev_weights"] = weights_var.get()
         result["threads"] = threads_var.get()
+        result["use_net_term"] = net_var.get()
+        result["use_sharpe_term"] = sharpe_var.get()
+        result["use_drawdown_term"] = dd_var.get()
+        result["use_trade_term"] = trade_var.get()
+        result["use_profit_days_term"] = days_var.get()
+        result["risk_filter"] = risk_var.get()
         root.quit()
         root.destroy()
 

--- a/run_artibot.py
+++ b/run_artibot.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from artibot.environment import ensure_dependencies
 from artibot.utils.torch_threads import set_threads
 from artibot.gui import startup_options_dialog
+import artibot.globals as G
 
 import os
 import sys
@@ -153,6 +154,12 @@ def main() -> None:
         "use_live": CONFIG.get("API", {}).get("LIVE_TRADING", False),
         "use_prev_weights": CONFIG.get("USE_PREV_WEIGHTS", True),
         "threads": CONFIG.get("CPU_LIMIT", os.cpu_count() or 1),
+        "use_net_term": G.use_net_term,
+        "use_sharpe_term": G.use_sharpe_term,
+        "use_drawdown_term": G.use_drawdown_term,
+        "use_trade_term": G.use_trade_term,
+        "use_profit_days_term": G.use_profit_days_term,
+        "risk_filter": G.is_risk_filter_enabled(),
     }
     opts = startup_options_dialog(defaults)
     global SKIP_SENTIMENT
@@ -164,6 +171,17 @@ def main() -> None:
 
     set_threads(int(opts.get("threads", defaults["threads"])))
     ensure_dependencies()
+
+    G.use_net_term = bool(opts.get("use_net_term", defaults["use_net_term"]))
+    G.use_sharpe_term = bool(opts.get("use_sharpe_term", defaults["use_sharpe_term"]))
+    G.use_drawdown_term = bool(
+        opts.get("use_drawdown_term", defaults["use_drawdown_term"])
+    )
+    G.use_trade_term = bool(opts.get("use_trade_term", defaults["use_trade_term"]))
+    G.use_profit_days_term = bool(
+        opts.get("use_profit_days_term", defaults["use_profit_days_term"])
+    )
+    G.set_risk_filter_enabled(bool(opts.get("risk_filter", defaults["risk_filter"])))
 
     from artibot.utils import setup_logging, get_device
     from artibot.ensemble import EnsembleModel
@@ -177,7 +195,6 @@ def main() -> None:
     from artibot.rl import MetaTransformerRL, meta_control_loop
     from artibot.validation import validate_and_gate
     from artibot.gui import TradingGUI
-    import artibot.globals as G
 
     setup_logging()
     root = tk.Tk()

--- a/tests/test_risk_filter_toggle.py
+++ b/tests/test_risk_filter_toggle.py
@@ -1,0 +1,9 @@
+import artibot.globals as G
+from artibot.ensemble import reject_if_risky
+
+
+def test_risk_filter_toggle():
+    G.set_risk_filter_enabled(False)
+    assert reject_if_risky(sharpe=0.5, max_dd=-0.4, entropy=0.1) is False
+    G.set_risk_filter_enabled(True)
+    assert reject_if_risky(sharpe=0.5, max_dd=-0.4, entropy=0.1) is True


### PR DESCRIPTION
## Summary
- extend globals with risk filter flag and helpers
- allow toggling reward terms and risk filter in startup dialog
- wire new options through `run_artibot`
- respect risk filter toggle in `reject_if_risky`
- test risk filter toggle behaviour

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: 24 failed, 96 passed, 5 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6865ad07fe7c83249aef4d419ba48130