### PR TITLE
Adjust risk curriculum

### DIFF
--- a/artibot/training.py
+++ b/artibot/training.py
@@ -58,12 +58,15 @@ def rebuild_loader(
 
 
 def apply_risk_curriculum(epoch: int) -> None:
-    """Adjust ``RISK_FILTER`` drawdown limits as training progresses."""
+    """Adjust ``RISK_FILTER`` thresholds as training progresses."""
     if epoch <= 20:
+        RISK_FILTER["MIN_SHARPE"] = -2.0
         RISK_FILTER["MAX_DRAWDOWN"] = -0.80
-    elif epoch <= 50:
+    elif epoch <= 40:
+        RISK_FILTER["MIN_SHARPE"] = -1.0
         RISK_FILTER["MAX_DRAWDOWN"] = -0.50
     else:
+        RISK_FILTER["MIN_SHARPE"] = 0.0
         RISK_FILTER["MAX_DRAWDOWN"] = -0.25
 
 

--- a/tests/test_risk_curriculum.py
+++ b/tests/test_risk_curriculum.py
@@ -1,0 +1,21 @@
+import importlib
+
+import artibot.hyperparams as hyperparams
+import artibot.training as training
+
+
+def test_apply_risk_curriculum():
+    importlib.reload(hyperparams)
+    importlib.reload(training)
+
+    training.apply_risk_curriculum(10)
+    assert hyperparams.RISK_FILTER["MIN_SHARPE"] == -2.0
+    assert hyperparams.RISK_FILTER["MAX_DRAWDOWN"] == -0.80
+
+    training.apply_risk_curriculum(30)
+    assert hyperparams.RISK_FILTER["MIN_SHARPE"] == -1.0
+    assert hyperparams.RISK_FILTER["MAX_DRAWDOWN"] == -0.50
+
+    training.apply_risk_curriculum(50)
+    assert hyperparams.RISK_FILTER["MIN_SHARPE"] == 0.0
+    assert hyperparams.RISK_FILTER["MAX_DRAWDOWN"] == -0.25


### PR DESCRIPTION
## Summary
- relax Sharpe ratio checks in `apply_risk_curriculum`
- add test for risk curriculum thresholds

## Testing
- `pre-commit run --files artibot/training.py tests/test_risk_curriculum.py`
- `pytest tests/test_risk_curriculum.py -q`
- `pytest -q` *(fails: dynamic tuning and other tests)*

------
https://chatgpt.com/codex/tasks/task_e_6865ae61534c832486b61c6c269c4081