### PR TITLE
Fix global best reward handling

### DIFF
--- a/artibot/ensemble.py
+++ b/artibot/ensemble.py
@@ -364,10 +364,12 @@ class EnsembleModel(nn.Module):
             G.global_monthly_stats_table = monthly_table
 
         # update live weights when the composite reward improves
-        if (
-            update_globals
-            and current_result["composite_reward"] > G.global_best_composite_reward
-        ):
+        best = (
+            G.global_best_composite_reward
+            if G.global_best_composite_reward is not None
+            else float("-inf")
+        )
+        if update_globals and current_result["composite_reward"] > best:
             G.global_best_composite_reward = current_result["composite_reward"]
             G.global_best_sharpe = max(G.global_best_sharpe, current_result["sharpe"])
             self.best_state_dicts = [m.state_dict() for m in self.models]

--- a/artibot/globals.py
+++ b/artibot/globals.py
@@ -128,7 +128,7 @@ global_best_avg_trade_duration = 0.0
 global_best_avg_win = 0.0
 global_best_avg_loss = 0.0
 global_best_inactivity_penalty = None
-global_best_composite_reward = None
+global_best_composite_reward = float("-inf")
 global_best_days_in_profit = None
 
 # Global best hyperparameters:

--- a/artibot/state.py
+++ b/artibot/state.py
@@ -1,0 +1,32 @@
+"""Lightweight training state loader and saver."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+from . import globals as G
+
+
+def load(path: str | os.PathLike = "checkpoint.json") -> dict[str, Any]:
+    """Load checkpoint ``path`` and update globals.
+
+    The file is optional; missing files return an empty dict.
+    ``G.global_best_composite_reward`` defaults to ``-inf`` when the key
+    is absent.
+    """
+    try:
+        with open(path, "r") as fh:
+            state = json.load(fh)
+    except OSError:
+        return {}
+
+    G.global_best_composite_reward = state.get("best_reward", float("-inf"))
+    return state
+
+
+def save(state: dict[str, Any], path: str | os.PathLike = "checkpoint.json") -> None:
+    """Persist ``state`` to ``path``."""
+    with open(path, "w") as fh:
+        json.dump(state, fh, indent=2)

--- a/tests/validate_loss.py
+++ b/tests/validate_loss.py
@@ -1,4 +1,6 @@
 import logging
+import json
+import pytest
 import threading
 
 import torch
@@ -29,3 +31,17 @@ def test_loss_regression(tmp_path, caplog):
     val = g.global_validation_loss[:n]
     assert tr and val
     assert max(tr) <= max(val) * 1.05
+
+
+@pytest.fixture
+def dummy_checkpoint(tmp_path):
+    path = tmp_path / "ckpt.json"
+    path.write_text(json.dumps({"foo": "bar"}))
+    return str(path)
+
+
+def test_best_reward_never_none_after_state_load(dummy_checkpoint):
+    from artibot import globals as G, state
+
+    state.load(dummy_checkpoint)
+    assert G.global_best_composite_reward is not None


### PR DESCRIPTION
## Summary
- prevent None comparison when updating best composite reward
- initialise `global_best_composite_reward` to `-inf`
- add simple state loader module
- extend loss regression test with a state-load regression check

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6865be2960b483249366e4b7adc216ca