### PR TITLE
Fix global_best_reward default

### DIFF
--- a/artibot/ensemble.py
+++ b/artibot/ensemble.py
@@ -364,10 +364,12 @@ class EnsembleModel(nn.Module):
             G.global_monthly_stats_table = monthly_table
 
         # update live weights when the composite reward improves
-        if (
-            update_globals
-            and current_result["composite_reward"] > G.global_best_composite_reward
-        ):
+        best = (
+            G.global_best_composite_reward
+            if G.global_best_composite_reward is not None
+            else float("-inf")
+        )
+        if update_globals and current_result["composite_reward"] > best:
             G.global_best_composite_reward = current_result["composite_reward"]
             G.global_best_sharpe = max(G.global_best_sharpe, current_result["sharpe"])
             self.best_state_dicts = [m.state_dict() for m in self.models]

--- a/artibot/state.py
+++ b/artibot/state.py
@@ -1,0 +1,13 @@
+import json
+import artibot.globals as G
+
+
+def load(path: str) -> dict:
+    """Load state from ``path`` and update globals."""
+    try:
+        with open(path, "r") as f:
+            state = json.load(f)
+    except Exception:
+        state = {}
+    G.global_best_composite_reward = state.get("best_reward", float("-inf"))
+    return state

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ import types
 import contextlib
 from importlib.machinery import ModuleSpec
 import numpy as np
+import pytest
 
 sys.modules.setdefault("openai", types.SimpleNamespace())
 
@@ -176,6 +177,14 @@ def pytest_configure(config):
         db.BinderException = Exception
         sys.modules["duckdb"] = db
 
+    if "sklearn" not in sys.modules:
+        sk = types.ModuleType("sklearn")
+        impute_mod = types.ModuleType("sklearn.impute")
+        impute_mod.KNNImputer = object
+        sk.impute = impute_mod
+        sys.modules["sklearn"] = sk
+        sys.modules["sklearn.impute"] = impute_mod
+
     if "matplotlib" not in sys.modules:
         matplotlib = types.ModuleType("matplotlib")
         matplotlib.use = lambda *a, **k: None
@@ -203,3 +212,10 @@ def pytest_configure(config):
         sched.every = every
         sched.run_pending = lambda: None
         sys.modules["schedule"] = sched
+
+
+@pytest.fixture
+def dummy_checkpoint(tmp_path):
+    path = tmp_path / "ckpt.json"
+    path.write_text("{}")
+    return path

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,6 @@
+from artibot import globals as G, state
+
+
+def test_best_reward_never_none_after_state_load(dummy_checkpoint):
+    state.load(dummy_checkpoint)
+    assert G.global_best_composite_reward is not None


### PR DESCRIPTION
## Summary
- avoid None comparison crash in `EnsembleModel.train_one_epoch`
- persist global best reward when loading state
- add regression test for state load

## Testing
- `pre-commit run --all-files`
- `pytest -q tests/test_state.py`

------
https://chatgpt.com/codex/tasks/task_e_6865be2960b483249366e4b7adc216ca