### PR TITLE
Fix meta-agent NaN, LR scheduler order, and feature mismatch

### DIFF
--- a/artibot/backtest.py
+++ b/artibot/backtest.py
@@ -225,8 +225,8 @@ def robust_backtest(
     if isinstance(data_full, list):
         data_full = np.array(data_full)
 
-    # [FIXED]# log incoming feature dimensions
-    print(f"[BACKTEST] Input feature dimension: {data_full.shape}")
+    # Log incoming feature dimension for debugging
+    print(f"[BACKTEST] Input feature dimension: {data_full.shape[1]}")
     from .constants import FEATURE_DIMENSION
 
     if data_full.shape[1] != FEATURE_DIMENSION:


### PR DESCRIPTION
## Summary
- sanitize state before each meta-agent action
- drop cosine scheduler from meta-agent
- update LR step logic
- compute holdout backtest features with build_features
- clarify backtest feature dimension log

## Testing
- `pre-commit run --all-files`
- `pytest -q tests/test_state.py`
- `python run_training.py --epochs 2 --no-gui` *(fails: can't open file)*

------
https://chatgpt.com/codex/tasks/task_e_6865c953406083249cec84bef043549d