### PR TITLE
Fix feature mismatch in backtest

### DIFF
--- a/artibot/training.py
+++ b/artibot/training.py
@@ -234,7 +234,10 @@ def csv_training_thread(
                 ensemble.max_reward_loss_weight,
                 ensemble.reward_loss_weight + 0.01,
             )
-            lr_now = ensemble.cycle[0].get_last_lr()[0]
+            if ensemble.cycle:
+                lr_now = ensemble.cycle[0].get_last_lr()[0]
+            else:
+                lr_now = ensemble.optimizers[0].param_groups[0]["lr"]
             attn_mean = (
                 float(np.mean(G.global_attention_weights_history[-100:]))
                 if G.global_attention_weights_history


### PR DESCRIPTION
## Summary
- disable per-batch schedulers to avoid PyTorch warning
- compute holdout features before backtesting
- guard learning-rate logging when scheduler disabled

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865d1fb294c8324a940918fe44c7575