### PR TITLE
Fix backtest input handling

### DIFF
--- a/artibot/ensemble.py
+++ b/artibot/ensemble.py
@@ -37,7 +37,6 @@ from torch.utils.data import DataLoader
 
 from .backtest import robust_backtest
 from .hyperparams import HyperParams, IndicatorHyperparams
-from .dataset import build_features
 from .utils.hardware import device as hw_device
 from .utils import zero_disabled
 import artibot.globals as G
@@ -308,11 +307,9 @@ class EnsembleModel(nn.Module):
         """
         # mutate shared state on the globals module
 
-        if len(data_full) == 0:
-            feats = np.zeros((0, FEATURE_DIMENSION), dtype=np.float32)
-        else:
-            feats = build_features(np.asarray(data_full), self.indicator_hparams)
-        current_result = robust_backtest(self, feats)
+        current_result = robust_backtest(self, data_full, indicators=features)
+        if data_full:
+            assert len(data_full[0]) >= 5, "Expect raw OHLCV rows"
 
         if update_globals:
             G.global_equity_curve = current_result["equity_curve"]

--- a/artibot/gui.py
+++ b/artibot/gui.py
@@ -562,8 +562,12 @@ class TradingGUI:
         try:
             valid_eq = [
                 (t, b)
-                for (t, b) in G.global_equity_curve
-                if isinstance(t, (int, float, np.integer, np.floating))
+                for pair in G.global_equity_curve
+                if isinstance(pair, (list, tuple))
+                and len(pair) == 2
+                and isinstance(pair[0], (int, float, np.integer, np.floating))
+                and pair[0] >= 946684800
+                for t, b in [pair]
             ]
             if valid_eq:
                 ts_, bs_ = zip(*valid_eq)
@@ -574,8 +578,12 @@ class TradingGUI:
             if G.global_best_equity_curve:
                 best_eq = [
                     (t, b)
-                    for (t, b) in G.global_best_equity_curve
-                    if isinstance(t, (int, float, np.integer, np.floating))
+                    for pair in G.global_best_equity_curve
+                    if isinstance(pair, (list, tuple))
+                    and len(pair) == 2
+                    and isinstance(pair[0], (int, float, np.integer, np.floating))
+                    and pair[0] >= 946684800
+                    for t, b in [pair]
                 ]
                 if best_eq:
                     t2, b2 = zip(*best_eq)

--- a/artibot/training.py
+++ b/artibot/training.py
@@ -11,7 +11,7 @@ import time
 import threading
 import os
 
-from .dataset import HourlyDataset, trailing_sma, build_features
+from .dataset import HourlyDataset, trailing_sma
 from .ensemble import reject_if_risky
 from .backtest import robust_backtest, compute_indicators
 from .feature_manager import enforce_feature_dim
@@ -208,10 +208,7 @@ def csv_training_thread(
             G.set_status("Training", status_msg)
 
             if holdout_data is not None and len(holdout_data) > 0:
-                feats = build_features(
-                    np.asarray(holdout_data), ensemble.indicator_hparams
-                )
-                holdout_res = robust_backtest(ensemble, feats)
+                holdout_res = robust_backtest(ensemble, holdout_data)
                 G.global_holdout_sharpe = holdout_res.get("sharpe", 0.0)
                 G.global_holdout_max_drawdown = holdout_res.get("max_drawdown", 0.0)
             else:

--- a/tests/test_backtest_io.py
+++ b/tests/test_backtest_io.py
@@ -1,0 +1,23 @@
+import types
+import sys
+import numpy as np
+import pytest
+import artibot.backtest as bt
+
+class DummyEnsemble:
+    device = "cpu"
+
+    def vectorized_predict(self, w, batch_size):
+        return np.zeros(len(w), dtype=int), None, {
+            "sl_multiplier": np.array(1.0),
+            "tp_multiplier": np.array(1.0),
+            "risk_fraction": np.array(0.1),
+        }
+
+def test_raw_ohlc_only():
+    dummy = DummyEnsemble()
+    raw = np.tile([1_600_000_000,1,1,1,1,100], (25,1))
+    bt.robust_backtest(dummy, raw)
+    bad = np.random.rand(25,16)
+    with pytest.raises(ValueError):
+        bt.robust_backtest(dummy, bad)


### PR DESCRIPTION
## Summary
- train on raw OHLCV rows instead of feature matrices
- assert raw row structure inside EnsembleModel
- validate input columns in `robust_backtest`
- filter invalid timestamps in GUI equity plots
- add regression test for wrong input type

## Testing
- `pre-commit run --all-files`
- `pytest tests/test_backtest_io.py -q`
- `pytest tests/test_backtest.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68662953b6fc83249fc45b61becca1b9