### PR TITLE
Reward & RL hardening

### DIFF
--- a/artibot/backtest.py
+++ b/artibot/backtest.py
@@ -572,8 +572,8 @@ def robust_backtest(
     avg_win = metrics["avg_win"]
     avg_loss = metrics["avg_loss"]
 
-    net_score = net_pct / 100.0
-    shr_score = sharpe
+    net_score = net_pct
+    shr_score = float(np.clip(sharpe, -1.0, 1.0))
     trade_count = len(trades)
     trade_term = trade_count * delta
     # final composite
@@ -585,11 +585,13 @@ def robust_backtest(
     if G.use_sharpe_term:
         composite_reward += beta * shr_score * 2
     if G.use_drawdown_term:
-        composite_reward += gamma * (1 - abs(mdd))
+        dd_term = float(np.clip(1 - abs(mdd), -1.0, 1.0))
+        composite_reward += gamma * dd_term
     if G.use_trade_term:
         composite_reward += trade_term * 3
     if G.use_profit_days_term:
-        composite_reward += (days_in_pf / 365) * 1000
+        composite_reward += (days_in_pf / 365) * 10
+    composite_reward -= tot_inact_pen
     return {
         "net_pct": net_pct,
         "trades": trade_count,

--- a/artibot/bot_app.py
+++ b/artibot/bot_app.py
@@ -108,7 +108,10 @@ def run_bot(max_epochs: int | None = None, *, overfit_toy: bool = False) -> None
     G.global_min_hold_seconds = config.get(
         "MIN_HOLD_SECONDS", G.global_min_hold_seconds
     )
-    openai.api_key = config["CHATGPT"]["API_KEY"]
+    openai.api_key = os.getenv(
+        "OPENAI_API_KEY",
+        config.get("CHATGPT", {}).get("API_KEY", ""),
+    )
     csv_path = config["CSV_PATH"]
     if not os.path.isabs(csv_path):
         here = os.path.dirname(os.path.abspath(__file__))

--- a/artibot/gui.py
+++ b/artibot/gui.py
@@ -258,8 +258,17 @@ def _fetch_position(exchange):
 
 
 class TradingGUI:
-    def __init__(self, root, ensemble, weights_path: str | None = None, connector=None):
+    def __init__(
+        self,
+        root,
+        ensemble,
+        weights_path: str | None = None,
+        connector=None,
+        *,
+        dev: bool = False,
+    ):
         global tk, ttk, matplotlib, plt, FigureCanvasTkAgg
+        self.dev = dev
         if tk is None:
             import tkinter as tk
             from tkinter import ttk
@@ -1506,15 +1515,18 @@ class TradingGUI:
             command=self.adjust_cpu_limit,
         )
         self.cpu_button.pack(side=tk.LEFT, padx=5)
-        self.force_nk_var = tk.BooleanVar(value=False)
-        self.force_nk_chk = ttk.Checkbutton(
-            self.controls_frame,
-            text="Bypass NK",
-            variable=self.force_nk_var,
-            command=self.on_toggle_force_nk,
-        )
-        self.force_nk_chk.pack(side=tk.LEFT, padx=5)
-        self.on_toggle_force_nk()
+        if self.dev:
+            self.force_nk_var = tk.BooleanVar(value=False)
+            self.force_nk_chk = ttk.Checkbutton(
+                self.controls_frame,
+                text="Bypass NK",
+                variable=self.force_nk_var,
+                command=self.on_toggle_force_nk,
+            )
+            self.force_nk_chk.pack(side=tk.LEFT, padx=5)
+            self.on_toggle_force_nk()
+        else:
+            G.nuke_armed = False
 
         self.validation_label = ttk.Label(
             self.info_frame, text="Validation: N/A", font=("Helvetica", 12)

--- a/artibot/live_risk.py
+++ b/artibot/live_risk.py
@@ -25,9 +25,19 @@ def update_auto_pause(sharpe: float, drawdown: float, ts: float | None = None) -
     dds = [d for t, d in G.live_drawdown_history if t >= day_ago]
 
     pause = False
+    if (
+        not hasattr(G, "daily_equity_start")
+        or ts - getattr(G, "daily_equity_start", 0) > DAY_SEC
+    ):
+        G.daily_equity_start = ts
+        G.daily_equity_reference = G.live_equity
     if sharpes and all(s < 1.0 for s in sharpes):
         pause = True
     if any(d < -0.10 for d in dds):
+        pause = True
+    if G.live_equity < G.start_equity * 0.8:
+        pause = True
+    if G.live_equity < getattr(G, "daily_equity_reference", G.live_equity) * 0.98:
         pause = True
 
     G.trading_paused = pause

--- a/artibot/training.py
+++ b/artibot/training.py
@@ -501,15 +501,21 @@ class PhemexConnector:
         api_conf = config.get("API", {})
         self.live_trading = bool(api_conf.get("LIVE_TRADING", True))
 
-        key = (
-            api_conf.get("API_KEY_LIVE", "")
-            if self.live_trading
-            else api_conf.get("API_KEY_TEST", "")
+        key = os.getenv(
+            "PHEMEX_KEY",
+            (
+                api_conf.get("API_KEY_LIVE", "")
+                if self.live_trading
+                else api_conf.get("API_KEY_TEST", "")
+            ),
         )
-        secret = (
-            api_conf.get("API_SECRET_LIVE", "")
-            if self.live_trading
-            else api_conf.get("API_SECRET_TEST", "")
+        secret = os.getenv(
+            "PHEMEX_SECRET",
+            (
+                api_conf.get("API_SECRET_LIVE", "")
+                if self.live_trading
+                else api_conf.get("API_SECRET_TEST", "")
+            ),
         )
 
         api_url_live = api_conf.get("API_URL_LIVE", "https://api.phemex.com")

--- a/exchanges.py
+++ b/exchanges.py
@@ -1,6 +1,7 @@
 """CCXT-based helper for simplified Phemex access."""
 
 import logging
+import os
 
 
 class ExchangeConnector:
@@ -13,13 +14,17 @@ class ExchangeConnector:
         self.symbol = "BTCUSD"
         api_conf = config.get("API", {})
         self.live = bool(api_conf.get("LIVE_TRADING", False))
-        key = (
-            api_conf.get("API_KEY_LIVE") if self.live else api_conf.get("API_KEY_TEST")
+        key = os.getenv(
+            "PHEMEX_KEY",
+            api_conf.get("API_KEY_LIVE") if self.live else api_conf.get("API_KEY_TEST"),
         )
-        secret = (
-            api_conf.get("API_SECRET_LIVE")
-            if self.live
-            else api_conf.get("API_SECRET_TEST")
+        secret = os.getenv(
+            "PHEMEX_SECRET",
+            (
+                api_conf.get("API_SECRET_LIVE")
+                if self.live
+                else api_conf.get("API_SECRET_TEST")
+            ),
         )
         default_type = api_conf.get("DEFAULT_TYPE", "swap")
         self.default_type = default_type

--- a/run_artibot.py
+++ b/run_artibot.py
@@ -17,6 +17,7 @@ import artibot.globals as G
 import os
 import sys
 import subprocess
+import argparse
 
 os.environ.setdefault("HF_HUB_DISABLE_SYMLINKS_WARNING", "1")
 
@@ -148,6 +149,11 @@ CONFIG = load_master_config()
 
 def main() -> None:
     """Prompt for startup options and run the trading bot."""
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dev", action="store_true")
+    args, _ = parser.parse_known_args()
+    dev_mode = args.dev
 
     defaults = {
         "skip_sentiment": False,
@@ -352,7 +358,7 @@ def main() -> None:
 
     threading.Thread(target=_bg_init, daemon=True).start()
 
-    gui = TradingGUI(root, ensemble, weights_path, connector)  # noqa: F841
+    TradingGUI(root, ensemble, weights_path, connector, dev=dev_mode)
 
     logging.info("Tkinter dashboard starting on main thread…")
 

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -1,0 +1,11 @@
+from artibot.rl import MetaTransformerRL
+
+class DummyEnsemble:
+    pass
+
+def test_rl_params():
+    agent = MetaTransformerRL(DummyEnsemble())
+    assert agent.eps_start == 0.20
+    assert agent.eps_end == 0.05
+    assert agent.eps_decay == 0.99
+    assert agent.entropy_beta == 0.005

--- a/tests/test_reward.py
+++ b/tests/test_reward.py
@@ -1,0 +1,26 @@
+import os, sys, types
+import numpy as np
+sys.modules['openai'] = types.SimpleNamespace()
+sys.modules['talib'] = types.SimpleNamespace(RSI=lambda a, timeperiod=14: np.zeros_like(a), MACD=lambda a, fastperiod=12, slowperiod=26, signalperiod=9: (np.zeros_like(a),np.zeros_like(a),np.zeros_like(a)), EMA=lambda a, timeperiod=20: np.zeros_like(a))
+from artibot.backtest import robust_backtest
+from artibot.hyperparams import IndicatorHyperparams
+
+class DummyEnsemble:
+    def __init__(self):
+        self.device = 'cpu'
+        self.indicator_hparams = IndicatorHyperparams()
+    def vectorized_predict(self, windows_t, batch_size=512):
+        preds = np.zeros(len(windows_t), dtype=np.int64)
+        import torch
+        avg = {
+            "sl_multiplier": torch.tensor(1.0),
+            "tp_multiplier": torch.tensor(1.0),
+            "risk_fraction": torch.tensor(0.1),
+        }
+        return torch.tensor(preds), None, avg
+
+def test_inactivity_penalty_applied():
+    data = [[i*86400,100,101,99,100,0] for i in range(60)]
+    result = robust_backtest(DummyEnsemble(), data)
+    assert result['inactivity_penalty'] > 0
+    assert 0 <= result['days_in_profit'] / 365 <= 1


### PR DESCRIPTION
## Summary
- rebalance composite reward formula
- retune PPO agent exploration and remove KL penalty
- normalise RL state inputs and enforce action constraints
- secure key usage with env vars and add risk checks
- add tests for reward and PPO params

## Testing
- `pre-commit run --all-files`
- `pytest -q tests/test_reward.py tests/test_params.py`

------
https://chatgpt.com/codex/tasks/task_e_68666d7fbb00832498926e855fa8944e