### PR TITLE
Add debug helpers for backtest pipeline

### DIFF
--- a/artibot/features.py
+++ b/artibot/features.py
@@ -39,3 +39,14 @@ class FeatureEngineer:
             features, self.expected_features, self.logger
         )
         return features
+
+
+def calculate_features(df: pd.DataFrame) -> np.ndarray:
+    """Wrapper around :class:`FeatureEngineer` with debug output."""
+
+    engineer = FeatureEngineer()
+    features = engineer.transform(df)
+    print(
+        f"[DEBUG] Post-feature shape: {features.shape}, Columns: {df.columns.tolist()}"
+    )
+    return features

--- a/data_loader.py
+++ b/data_loader.py
@@ -1,10 +1,23 @@
 from artibot.constants import FEATURE_DIMENSION
 import numpy as np
 from artibot.feature_manager import sanitize_features
-from artibot.utils import enforce_feature_dim, validate_features, feature_mask_for
+from artibot.utils import (
+    enforce_feature_dim,
+    validate_features,
+    feature_mask_for,
+)
 from artibot.hyperparams import IndicatorHyperparams
 import os
 import joblib
+import pandas as pd
+
+
+def load_backtest_data(path: str) -> pd.DataFrame:
+    """Load raw CSV data for backtesting with a debug summary."""
+
+    df = pd.read_csv(path)
+    print(f"[DEBUG] Raw CSV shape: {df.shape}, Columns: {df.columns.tolist()}")
+    return df
 
 
 def load_and_clean_data(
@@ -48,3 +61,15 @@ def load_and_clean_data(
         pass
 
     return data
+
+
+def get_backtest_data() -> np.ndarray:
+    """Load, process and return data for debugging the pipeline."""
+
+    data = load_backtest_data("path.csv")
+    print(f"[PRE-FEATURE] Data shape: {data.shape}")
+    from artibot.features import calculate_features
+
+    processed = calculate_features(data)
+    print(f"[POST-FEATURE] Data shape: {processed.shape}")
+    return processed


### PR DESCRIPTION
## Summary
- add `load_backtest_data` and `get_backtest_data` utilities
- provide `calculate_features` helper with debug output

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: ModuleNotFoundError and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6866f7d7bde48324bbc396c68b3ec573