### PR TITLE
Integrate feature engineering with backtest data loader

### DIFF
--- a/data_loader.py
+++ b/data_loader.py
@@ -7,6 +7,8 @@ from artibot.utils import (
     feature_mask_for,
 )
 from artibot.hyperparams import IndicatorHyperparams
+from feature_engineering import calculate_technical_indicators
+import config
 import os
 import joblib
 import pandas as pd
@@ -16,6 +18,11 @@ def load_backtest_data(path: str) -> pd.DataFrame:
     """Load raw CSV data for backtesting with a debug summary."""
 
     df = pd.read_csv(path)
+
+    if not set(config.FEATURE_CONFIG["feature_columns"]).issubset(df.columns):
+        print("🚨 Backtest data missing features - calculating indicators...")
+        df = calculate_technical_indicators(df)
+
     print(f"[DEBUG] Raw CSV shape: {df.shape}, Columns: {df.columns.tolist()}")
     return df
 

--- a/feature_engineering.py
+++ b/feature_engineering.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+import config
+from artibot.dataset import generate_fixed_features
+from artibot.hyperparams import IndicatorHyperparams
+
+
+def calculate_technical_indicators(df: pd.DataFrame) -> pd.DataFrame:
+    """Return DataFrame of engineered features for ``df``."""
+
+    data = df.copy()
+    data.columns = [c.strip().lower().replace(" ", "_") for c in data.columns]
+
+    volume_col = None
+    for col in ("volume_btc", "volume", "volume_usd"):
+        if col in data.columns:
+            volume_col = col
+            break
+    if volume_col is None:
+        volume_col = "volume"
+        data[volume_col] = 0.0
+
+    if "unix" not in data.columns:
+        data["unix"] = np.arange(len(data))
+
+    arr = data[["unix", "open", "high", "low", "close", volume_col]].to_numpy(
+        dtype=float
+    )
+
+    feats = generate_fixed_features(arr, IndicatorHyperparams())
+    print(
+        f"✅ Calculated {feats.shape[1]} features from raw {df.shape[1]}-column input"
+    )
+
+    feature_cols = config.FEATURE_CONFIG.get("feature_columns", [])
+    return pd.DataFrame(feats, columns=feature_cols)


### PR DESCRIPTION
## Summary
- compute technical features when loading backtest CSVs
- expose `calculate_technical_indicators` helper

## Testing
- `pre-commit run --all-files`
- `pytest tests/test_feature_dim.py::test_add_technical_flags -q --no-heavy`

------
https://chatgpt.com/codex/tasks/task_e_6866fdb6261c8324b67c05924e0b73cc