### PR TITLE
Integrate loader in backtest module

### DIFF
--- a/backtest.py
+++ b/backtest.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Any
+
+import config
+from data_loader import load_backtest_data
+
+
+def run_backtest(strategy: Any, data_path: str):
+    """Run a strategy on CSV data using engineered features.
+
+    Parameters
+    ----------
+    strategy:
+        Object exposing a ``run`` method accepting ``features`` and
+        ``timestamps`` arrays.
+    data_path:
+        Path to the CSV file containing at least a ``timestamp`` column.
+    """
+
+    df = load_backtest_data(data_path)
+
+    timestamps = df["timestamp"].values
+    feature_cols = getattr(
+        config, "FEATURE_COLUMNS", config.FEATURE_CONFIG["feature_columns"]
+    )
+    feature_matrix = df[feature_cols].values
+
+    if feature_matrix.shape[1] != len(feature_cols):
+        raise ValueError(
+            f"Backtest requires {len(feature_cols)} features, "
+            f"got {feature_matrix.shape[1]}. Check data pipeline!"
+        )
+
+    print(
+        f"[BACKTEST] Loaded {len(feature_matrix)} candles with {feature_matrix.shape[1]} validated features"
+    )
+
+    results = strategy.run(feature_matrix, timestamps)
+    return results

--- a/config.py
+++ b/config.py
@@ -20,3 +20,6 @@ FEATURE_CONFIG = {
         "atr",
     ],
 }
+
+# Convenient alias for core modules
+FEATURE_COLUMNS = FEATURE_CONFIG["feature_columns"]

--- a/data_loader.py
+++ b/data_loader.py
@@ -15,13 +15,24 @@ import pandas as pd
 
 
 def load_backtest_data(path: str) -> pd.DataFrame:
-    """Load raw CSV data for backtesting with a debug summary."""
+    """Load raw CSV data for backtesting with a debug summary.
+
+    The ``timestamp`` column is preserved so sequencing remains valid after
+    feature engineering.
+    """
 
     df = pd.read_csv(path)
+
+    if "timestamp" not in df.columns:
+        raise KeyError("CSV must contain 'timestamp' column")
+
+    timestamps = df["timestamp"].copy()
 
     if not set(config.FEATURE_CONFIG["feature_columns"]).issubset(df.columns):
         print("🚨 Backtest data missing features - calculating indicators...")
         df = calculate_technical_indicators(df)
+
+    df["timestamp"] = timestamps
 
     print(f"[DEBUG] Raw CSV shape: {df.shape}, Columns: {df.columns.tolist()}")
     return df


### PR DESCRIPTION
## Summary
- provide alias `FEATURE_COLUMNS` in `config`
- preserve timestamp handling in `load_backtest_data`
- add new `run_backtest` helper using engineered features

## Testing
- `pre-commit run --files backtest.py data_loader.py config.py`
- `pytest tests/test_skip_sentiment.py::test_skip_sentiment_yes -q`

------
https://chatgpt.com/codex/tasks/task_e_686701f0fa04832490a0342c5f484822