### PR TITLE
Fix backtest feature pipeline

### DIFF
--- a/backtest.py
+++ b/backtest.py
@@ -2,39 +2,29 @@ from __future__ import annotations
 
 from typing import Any
 
-import config
 from data_loader import load_backtest_data
 
 
 def run_backtest(strategy: Any, data_path: str):
-    """Run a strategy on CSV data using engineered features.
+    """Run ``strategy`` on processed features from ``data_path``."""
 
-    Parameters
-    ----------
-    strategy:
-        Object exposing a ``run`` method accepting ``features`` and
-        ``timestamps`` arrays.
-    data_path:
-        Path to the CSV file containing at least a ``timestamp`` column.
-    """
-
+    # Load and process data with feature engineering
     df = load_backtest_data(data_path)
 
-    timestamps = df["timestamp"].values
-    feature_cols = getattr(
-        config, "FEATURE_COLUMNS", config.FEATURE_CONFIG["feature_columns"]
-    )
-    feature_matrix = df[feature_cols].values
+    # Extract features and validate dimensions
+    feature_cols = [col for col in df.columns if col != "timestamp"]
+    features = df[feature_cols].values
 
-    if feature_matrix.shape[1] != len(feature_cols):
+    # Critical dimension check
+    expected_features = 16  # From config
+    if features.shape[1] != expected_features:
         raise ValueError(
-            f"Backtest requires {len(feature_cols)} features, "
-            f"got {feature_matrix.shape[1]}. Check data pipeline!"
+            f"Backtest requires {expected_features} features, "
+            f"got {features.shape[1]}. Check data pipeline!"
         )
 
-    print(
-        f"[BACKTEST] Loaded {len(feature_matrix)} candles with {feature_matrix.shape[1]} validated features"
-    )
+    # Debug log for verification
+    print(f"[BACKTEST] Running with {features.shape[1]} validated features")
 
-    results = strategy.run(feature_matrix, timestamps)
-    return results
+    # Run strategy
+    return strategy.run(features, df["timestamp"].values)

--- a/data_loader.py
+++ b/data_loader.py
@@ -8,33 +8,30 @@ from artibot.utils import (
 )
 from artibot.hyperparams import IndicatorHyperparams
 from feature_engineering import calculate_technical_indicators
-import config
 import os
 import joblib
 import pandas as pd
 
 
 def load_backtest_data(path: str) -> pd.DataFrame:
-    """Load raw CSV data for backtesting with a debug summary.
-
-    The ``timestamp`` column is preserved so sequencing remains valid after
-    feature engineering.
-    """
+    """Return DataFrame with engineered features for backtesting."""
 
     df = pd.read_csv(path)
+    print(f"[LOADER] Raw columns: {df.columns.tolist()}")
 
     if "timestamp" not in df.columns:
         raise KeyError("CSV must contain 'timestamp' column")
 
     timestamps = df["timestamp"].copy()
 
-    if not set(config.FEATURE_CONFIG["feature_columns"]).issubset(df.columns):
-        print("🚨 Backtest data missing features - calculating indicators...")
+    # Calculate missing features
+    if "sma_10" not in df.columns:
+        print("\ud83d\udd27 Calculating technical indicators...")
         df = calculate_technical_indicators(df)
 
     df["timestamp"] = timestamps
 
-    print(f"[DEBUG] Raw CSV shape: {df.shape}, Columns: {df.columns.tolist()}")
+    print(f"[LOADER] Processed columns: {df.columns.tolist()}")
     return df
 
 


### PR DESCRIPTION
## Summary
- ensure backtests use engineered feature columns
- log raw vs processed columns when loading data

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_6867086a7f4c8324a671551cf1581165