### PR TITLE
Fix indicator padding in backtest

### DIFF
--- a/artibot/backtest.py
+++ b/artibot/backtest.py
@@ -35,10 +35,10 @@ def prepare_backtest_data(data: np.ndarray) -> np.ndarray:
     """Validate and return ``data`` for backtesting."""
 
     expected = len(FEATURE_CONFIG.get("feature_columns", []))
-    assert (
-        data.shape[1] == expected
-    ), f"Expected {expected} features, got {data.shape[1]}"
-    return data
+    hp = IndicatorHyperparams()
+    fixed = compute_indicators(data, hp)["features"]
+    assert fixed.shape[1] == expected, f"wanted {expected}, got {fixed.shape[1]}"
+    return fixed
 
 
 def compute_indicators(


### PR DESCRIPTION
## Summary
- ensure OHLCV data is padded with indicators before validating in `prepare_backtest_data`

## Testing
- `pre-commit run --files artibot/backtest.py`
- `pytest tests/test_feature_manager.py::test_enforce_feature_dim_padding -q --no-heavy`

------
https://chatgpt.com/codex/tasks/task_e_686872232e108324bbd7ade9d4e38383