### PR TITLE
Enable CUDA on Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        torch: [cpu, cu121]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -11,7 +14,11 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -U pip
-          pip install numpy pandas torch matplotlib ccxt --extra-index-url https://download.pytorch.org/whl/cpu
+          if [ "${{ matrix.torch }}" = "cu121" ]; then
+            pip install numpy pandas torch torchvision torchaudio matplotlib ccxt --extra-index-url https://download.pytorch.org/whl/cu121
+          else
+            pip install numpy pandas torch matplotlib ccxt --extra-index-url https://download.pytorch.org/whl/cpu
+          fi
       - name: Run tests
         env:
           PYTHONPATH: ${{ github.workspace }}

--- a/README.md
+++ b/README.md
@@ -90,6 +90,16 @@ pip install torch openai ccxt pandas numpy matplotlib scikit-learn TA-Lib pytest
 Users on Python 3.11 should install a CUDA 12.1 build of PyTorch 2.x to enable
 GPU acceleration. The bot falls back to CPU when no compatible wheel is found.
 
+### GPU quick-start
+
+```bash
+pip install --upgrade pip
+pip install --extra-index-url https://download.pytorch.org/whl/cu121 \
+    torch torchvision torchaudio --force-reinstall --no-cache-dir
+```
+
+Windows and Linux both require an NVIDIA driver version 545.23 or newer for CUDA 12.1.
+
 The environment sets `NUMEXPR_MAX_THREADS` to the CPU count when the variable is
 not defined, downgrades NumPy to the latest 1.x release for legacy packages and
 chooses the correct CPU or CUDA build of PyTorch automatically.  Set

--- a/artibot/__init__.py
+++ b/artibot/__init__.py
@@ -7,8 +7,10 @@ the installer ran once on first launch.
 
 # ruff: noqa: E402
 from .environment import ensure_dependencies
+from .core.device import check_cuda
 
 ensure_dependencies()  # run the installer once at import time
+check_cuda()
 from config import FEATURE_CONFIG
 from .constants import FEATURE_DIMENSION
 

--- a/artibot/backtest.py
+++ b/artibot/backtest.py
@@ -645,7 +645,7 @@ if __name__ == "__main__":
     from .dataset import load_csv_hourly, HourlyDataset
     from .ensemble import EnsembleModel
     from .training import csv_training_thread
-    from .utils import get_device
+    from artibot.core.device import get_device
     from .hyperparams import IndicatorHyperparams
     from .bot_app import CONFIG
     import threading

--- a/artibot/bot_app.py
+++ b/artibot/bot_app.py
@@ -151,7 +151,7 @@ def run_bot(max_epochs: int | None = None, *, overfit_toy: bool = False) -> None
     else:
         use_prev_weights = False
 
-    from .utils import get_device
+    from artibot.core.device import get_device
 
     device = get_device()
     msg = f"Using device: {device.type}"

--- a/artibot/core/device.py
+++ b/artibot/core/device.py
@@ -1,18 +1,39 @@
 import logging
+import subprocess
 
-try:  # torch may be mocked or missing during tests
-    import torch
+import torch
 
+log = logging.getLogger("device")
+
+
+def get_device() -> torch.device:
+    """Return CUDA device when available, otherwise CPU."""
+
+    if torch.cuda.is_available():
+        idx = torch.cuda.current_device()
+        name = torch.cuda.get_device_name(idx)
+        log.info("Using CUDA device %s: %s", idx, name)
+        return torch.device("cuda", idx)
+    log.warning("CUDA not available – falling back to CPU")
+    return torch.device("cpu")
+
+
+DEVICE = get_device()
+
+
+def check_cuda() -> None:
+    """Warn when CUDA support is missing."""
+
+    has_cuda = torch.version.cuda is not None
     try:
-        _has_cuda = torch.cuda.is_available()
-    except AttributeError:
-        _has_cuda = False
-    DEVICE = torch.device("cuda" if _has_cuda else "cpu")
-except Exception:  # pragma: no cover - torch absent
-
-    class _CPU:
-        type = "cpu"
-
-    DEVICE = _CPU()
-
-logging.info("Using device: %s", getattr(DEVICE, "type", DEVICE))
+        ret = subprocess.call(
+            ["nvidia-smi"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+        )
+    except Exception:
+        ret = 1
+    if not (has_cuda and ret == 0):
+        msg = (
+            "torch-cu121 wheel not installed or driver < 545; "
+            "see README 'CUDA 12.1' section"
+        )
+        print(f"\033[91m{msg}\033[0m")

--- a/artibot/dataset.py
+++ b/artibot/dataset.py
@@ -424,11 +424,13 @@ class HourlyDataset(Dataset):
         assert (
             sample.shape[1] == self.expected_features
         ), f"Expected {self.expected_features} features, got {sample.shape[1]}"
-        sample_t = torch.as_tensor(sample, dtype=torch.float32)
+        from .core.device import DEVICE
+
+        sample_t = torch.as_tensor(sample, dtype=torch.float32, device=DEVICE)
         label = self.labels[idx]
         if self.rebalance and label == 2 and random.random() < 0.5:
             label = random.choice([0, 1])
-        label_t = torch.tensor(label, dtype=torch.long)
+        label_t = torch.tensor(label, dtype=torch.long, device=DEVICE)
         return sample_t, label_t
 
     # [FIXED]# expose expected feature dimension

--- a/artibot/utils/__init__.py
+++ b/artibot/utils/__init__.py
@@ -9,7 +9,7 @@ import json
 
 import math
 import torch
-from ..core.device import DEVICE
+from ..core.device import get_device as _core_get_device
 import pandas as pd
 import numpy as np
 import hashlib
@@ -33,7 +33,7 @@ CONTEXT_FLAGS = ("use_sentiment", "use_macro", "use_rvol")
 
 def get_device() -> torch.device:
     """Return detected hardware device."""
-    return DEVICE
+    return _core_get_device()
 
 
 class JsonFormatter(logging.Formatter):

--- a/artibot/utils/heartbeat.py
+++ b/artibot/utils/heartbeat.py
@@ -8,10 +8,10 @@ import threading
 import time
 from typing import Any
 
-try:  # optional dependency
-    import psutil
-except Exception:  # pragma: no cover - optional dep not installed
-    psutil = None
+import tomllib
+import torch
+import psutil
+from nvidia import nvml
 
 _LOCK = threading.Lock()
 
@@ -25,8 +25,33 @@ def update(**kwargs: Any) -> None:
         LATEST_STATS.update(kwargs)
 
 
-def start(interval: int = 120) -> None:
+def sample() -> dict[str, Any]:
+    """Return CPU, memory and optional GPU utilisation."""
+
+    cpu = f"{psutil.cpu_percent():.1f}%"
+    mem = f"{psutil.virtual_memory().percent:.1f}%"
+    gpu, vram = None, None
+    if torch.cuda.is_available():
+        nvml.nvmlInit()
+        h = nvml.nvmlDeviceGetHandleByIndex(torch.cuda.current_device())
+        util = nvml.nvmlDeviceGetUtilizationRates(h)
+        meminfo = nvml.nvmlDeviceGetMemoryInfo(h)
+        gpu = f"{util.gpu}%"
+        vram = f"{meminfo.used / meminfo.total * 100:.1f}%"
+        nvml.nvmlShutdown()
+    return dict(cpu=cpu, mem=mem, gpu=gpu, vram=vram)
+
+
+def start(interval: int | None = None) -> None:
     """Start a background heartbeat logger."""
+
+    if interval is None:
+        try:
+            with open("config/default.toml", "rb") as fh:
+                cfg = tomllib.load(fh)
+                interval = int(cfg.get("logging", {}).get("heartbeat_interval", 120))
+        except Exception:
+            interval = 120
 
     def _beat() -> None:
         while True:
@@ -34,11 +59,8 @@ def start(interval: int = 120) -> None:
                 stats = {
                     "event": "HEARTBEAT",
                     "ts": time.ctime(),
-                    "epoch": LATEST_STATS.get("epoch"),
-                    "candidate": LATEST_STATS.get("candidate"),
-                    "best_sharpe": LATEST_STATS.get("best_sharpe"),
-                    "cpu": f"{psutil.cpu_percent()}%" if psutil else "0%",
-                    "mem": f"{psutil.virtual_memory().percent}%" if psutil else "0%",
+                    **sample(),
+                    **LATEST_STATS,
                 }
             logging.info(json.dumps(stats))
             time.sleep(interval)

--- a/artibot/validation.py
+++ b/artibot/validation.py
@@ -19,7 +19,7 @@ from .dataset import load_csv_hourly, HourlyDataset
 from .ensemble import EnsembleModel
 from .hyperparams import HyperParams, IndicatorHyperparams
 from .training import csv_training_thread
-from .utils import get_device
+from artibot.core.device import get_device
 
 YEAR_HOURS = 365 * 24
 MONTH_SECONDS = 30 * 24 * 3600

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,7 @@
+--extra-index-url https://download.pytorch.org/whl/cu121
+torch==2.2.0+cu121
+torchvision==0.17.0+cu121
+torchaudio==2.2.0+cu121
 ccxt~=4.2
+psutil~=7.0
+nvidia-ml-py3~=7.352

--- a/run_artibot.py
+++ b/run_artibot.py
@@ -201,7 +201,8 @@ def main() -> None:
     )
     G.set_risk_filter_enabled(bool(opts.get("risk_filter", defaults["risk_filter"])))
 
-    from artibot.utils import setup_logging, get_device
+    from artibot.utils import setup_logging
+    from artibot.core.device import get_device
     from artibot.ensemble import EnsembleModel
     from artibot.dataset import HourlyDataset, load_csv_hourly
     from artibot.hyperparams import HyperParams, IndicatorHyperparams

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,0 +1,5 @@
+from artibot.core.device import get_device
+
+
+def test_get_device():
+    assert get_device().type in {"cuda", "cpu"}

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -15,13 +15,20 @@ sys.modules.setdefault(
     "matplotlib",
     types.SimpleNamespace(use=lambda *a, **k: None),
 )
+sys.modules.setdefault(
+    "nvidia",
+    types.SimpleNamespace(
+        nvml=types.SimpleNamespace(
+            nvmlInit=lambda: None,
+            nvmlDeviceGetHandleByIndex=lambda idx: object(),
+            nvmlDeviceGetUtilizationRates=lambda h: types.SimpleNamespace(gpu=0),
+            nvmlDeviceGetMemoryInfo=lambda h: types.SimpleNamespace(used=0, total=1),
+            nvmlShutdown=lambda: None,
+        )
+    ),
+)
 
-from artibot.core.device import DEVICE
 from artibot.utils import heartbeat
-
-
-def test_device_constant():
-    assert getattr(DEVICE, "type", str(DEVICE)) in {"cuda", "cpu"}
 
 
 def test_heartbeat_logging(monkeypatch):

--- a/tests/test_heartbeat_gpu.py
+++ b/tests/test_heartbeat_gpu.py
@@ -1,0 +1,26 @@
+import sys
+import types
+
+
+def test_heartbeat_gpu(monkeypatch):
+    cuda_mod = types.SimpleNamespace(
+        is_available=lambda: True,
+        current_device=lambda: 0,
+        get_device_name=lambda idx: "GPU",
+    )
+    torch_mod = types.SimpleNamespace(cuda=cuda_mod)
+    monkeypatch.setitem(sys.modules, "torch", torch_mod)
+
+    nvml_mod = types.SimpleNamespace(
+        nvmlInit=lambda: None,
+        nvmlDeviceGetHandleByIndex=lambda idx: object(),
+        nvmlDeviceGetUtilizationRates=lambda h: types.SimpleNamespace(gpu=55),
+        nvmlDeviceGetMemoryInfo=lambda h: types.SimpleNamespace(used=5, total=10),
+        nvmlShutdown=lambda: None,
+    )
+    monkeypatch.setitem(sys.modules, "nvidia", types.SimpleNamespace(nvml=nvml_mod))
+
+    from artibot.utils.heartbeat import sample
+
+    res = sample()
+    assert "gpu" in res and "vram" in res

--- a/tests/test_risk_filter.py
+++ b/tests/test_risk_filter.py
@@ -19,4 +19,3 @@ def test_risk_filter_apply():
 
     disabled = risk_filter(df, enabled=False)
     assert len(disabled) == 3
-


### PR DESCRIPTION
## Summary
- install CUDA wheels and GPU metrics libs in requirements.txt
- add GPU device helper and failsafe check
- wire device helper across the codebase
- track GPU metrics in heartbeat util
- document quick start for CUDA 12.1
- cover GPU path in CI and add tests

## Testing
- `pre-commit run --all-files`
- `pytest tests/test_device.py tests/test_heartbeat_gpu.py tests/test_heartbeat.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6869cd202c8c8324acfa6eb36649c780