### PR TITLE
Enable pinned memory and lazy data windows

### DIFF
--- a/tests/test_csv_workers.py
+++ b/tests/test_csv_workers.py
@@ -15,6 +15,7 @@ def test_csv_thread_uses_config(monkeypatch):
     def fake_loader(*args, **kwargs):
         called["workers"] = kwargs.get("num_workers")
         called["persistent"] = kwargs.get("persistent_workers")
+        called["pinned"] = kwargs.get("pin_memory")
 
         class DL:
             pass
@@ -44,6 +45,7 @@ def test_csv_thread_uses_config(monkeypatch):
 
     assert called.get("workers") == 3
     assert called.get("persistent") is True
+    assert called.get("pinned") is True
 
 
 def test_persistent_workers_enabled(monkeypatch):
@@ -52,6 +54,7 @@ def test_persistent_workers_enabled(monkeypatch):
 
     def fake_loader(*args, **kwargs):
         called["persistent"] = kwargs.get("persistent_workers")
+        called["pinned"] = kwargs.get("pin_memory")
 
         class DL:
             pass
@@ -78,3 +81,4 @@ def test_persistent_workers_enabled(monkeypatch):
     csv_training_thread(ens, data, stop, {}, use_prev_weights=False, max_epochs=1)
 
     assert called.get("persistent") is True
+    assert called.get("pinned") is True

--- a/tests/test_entropy_warning.py
+++ b/tests/test_entropy_warning.py
@@ -56,7 +56,7 @@ def test_entropy_warning(monkeypatch, caplog):
     ens.optimizers = [torch.optim.AdamW(ens.models[0].parameters(), lr=1e-3)]
 
     ds = TensorDataset(torch.zeros(1, 24, 8), torch.zeros(1, dtype=torch.long))
-    dl = DataLoader(ds, batch_size=1)
+    dl = DataLoader(ds, batch_size=1, pin_memory=True)
 
     caplog.set_level(logging.WARNING)
     G.global_attention_entropy_history = [0.4] * 120

--- a/tests/test_logging_update.py
+++ b/tests/test_logging_update.py
@@ -86,7 +86,7 @@ def build_dummy_ensemble(monkeypatch):
     monkeypatch.setattr("artibot.ensemble.compute_yearly_stats", dummy_stats)
 
     ds = TensorDataset(torch.zeros(1, 24, 8), torch.zeros(1, dtype=torch.long))
-    dl = DataLoader(ds, batch_size=1)
+    dl = DataLoader(ds, batch_size=1, pin_memory=True)
     return ens, dl
 
 

--- a/tests/test_new_best_logging.py
+++ b/tests/test_new_best_logging.py
@@ -72,7 +72,7 @@ def test_new_best_logging(monkeypatch, caplog):
     ens.optimizers = [torch.optim.AdamW(ens.models[0].parameters(), lr=1e-3)]
 
     ds = TensorDataset(torch.zeros(1, 24, 8), torch.zeros(1, dtype=torch.long))
-    dl = DataLoader(ds, batch_size=1)
+    dl = DataLoader(ds, batch_size=1, pin_memory=True)
 
     G.global_attention_entropy_history = [1.2]
     G.global_sharpe = 1.2

--- a/tests/test_train_one_epoch_runs.py
+++ b/tests/test_train_one_epoch_runs.py
@@ -54,6 +54,6 @@ def test_train_one_epoch_runs(monkeypatch):
     ens.optimizers = [torch.optim.AdamW(ens.models[0].parameters(), lr=1e-3)]
 
     ds = TensorDataset(torch.zeros(2, 24, 16), torch.zeros(2, dtype=torch.long))
-    dl = DataLoader(ds, batch_size=1)
+    dl = DataLoader(ds, batch_size=1, pin_memory=True)
 
     ens.train_one_epoch(dl, dl, [])


### PR DESCRIPTION
## Summary
- use pin_memory=True for training DataLoaders
- add profiling helper using `torch.profiler`
- lazily slice windows in `HourlyDataset` instead of precomputing
- update tests for pinned memory

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: 33 failed, 99 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686b0e39f730832489a63d98ce4f109c