### PR TITLE
Fix DataLoader pin memory crash

### DIFF
--- a/artibot/core/device.py
+++ b/artibot/core/device.py
@@ -2,6 +2,7 @@ import importlib
 import logging
 import subprocess
 import sys
+import os
 
 import torch
 
@@ -44,10 +45,11 @@ def _install_cuda() -> None:
         log.error("CUDA wheel install failed: %s", e)
 
 
-try:
-    _install_cuda()
-except Exception:
-    log.exception("unexpected CUDA-install failure")
+if os.environ.get("ARTIBOT_SKIP_INSTALL") != "1":
+    try:
+        _install_cuda()
+    except Exception:
+        log.exception("unexpected CUDA-install failure")
 
 
 def get_device() -> torch.device:

--- a/artibot/dataset.py
+++ b/artibot/dataset.py
@@ -397,13 +397,11 @@ class HourlyDataset(Dataset):
         if self.train_mode and random.random() < 0.2:
             sample += np.random.normal(0, 0.01, sample.shape)
 
-        from .core.device import DEVICE
-
-        sample_t = torch.as_tensor(sample, dtype=torch.float32, device=DEVICE)
+        sample_t = torch.as_tensor(sample, dtype=torch.float32)
         label = self.labels[idx]
         if self.rebalance and label == 2 and random.random() < 0.5:
             label = random.choice([0, 1])
-        label_t = torch.tensor(label, dtype=torch.long, device=DEVICE)
+        label_t = torch.tensor(label, dtype=torch.long)
         return sample_t, label_t
 
     # convenience for external callers


### PR DESCRIPTION
## Summary
- avoid moving data to GPU inside `HourlyDataset.__getitem__`
- guard CUDA auto-install when `ARTIBOT_SKIP_INSTALL=1`

## Testing
- `pre-commit run --all-files`
- `pytest tests/test_dataset.py::test_hourlydataset_basic -q`

------
https://chatgpt.com/codex/tasks/task_e_686b224ed1688324aa5c34c6149b11f9