### PR TITLE
Add config axes & sweep tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,14 @@ stop‑loss/take‑profit parameters and ATR threshold:
 }
 ```
 
+### Window-Length & Hyperparameter Sweep
+
+Define `experiment_axes` in your config YAML and run:
+
+```bash
+python scripts/sweep.py --config-file config/hyperparams.yaml
+```
+
 ## Usage
 
 Start the bot and follow the prompt to choose live or sandbox mode:

--- a/artibot/rl.py
+++ b/artibot/rl.py
@@ -155,7 +155,7 @@ class MetaTransformerRL:
         # Reward shaping baseline (EMA of |Δreward|)
         self.reward_ema = 1.0
         self.tau_inv = 1.0 / 50.0
-        self.entropy_beta = 0.005
+        self.entropy_beta = math.exp(_random.uniform(math.log(1e-4), math.log(5e-3)))
         self.low_kl_count = 0
 
         # (7) Scheduled exploration

--- a/artibot/training.py
+++ b/artibot/training.py
@@ -324,7 +324,12 @@ def csv_training_thread(
             entropy = attn_entropy
             if overfit_toy:
                 print(f"Toy epoch {epochs} loss {tl:.4f}")
-            if not overfit_toy and reject_if_risky(reward_val, max_dd, entropy):
+            skip_risk_check = ensemble.train_steps < 3
+            if (
+                not overfit_toy
+                and not skip_risk_check
+                and reject_if_risky(reward_val, max_dd, entropy)
+            ):
                 logging.info(
                     "REJECTED",
                     extra={

--- a/config/hyperparams.yaml
+++ b/config/hyperparams.yaml
@@ -1,0 +1,17 @@
+experiment_axes:
+  window_length:
+    sampling: log_uniform
+    min: 64
+    max: 512
+  reward_weights:
+    sampling: dirichlet
+  learning_rate:
+    sampling: log_uniform
+    min: 1e-6
+    max: 1e-2
+  entropy_beta:
+    sampling: log_uniform
+    min: 1e-4
+    max: 5e-3
+  attention_impl:
+    choices: [standard_eager, flash_attention_v2]

--- a/scripts/sweep.py
+++ b/scripts/sweep.py
@@ -1,111 +1,133 @@
 #!/usr/bin/env python3
-"""Grid search over LR and TP/SL multipliers."""
+"""Hyperparameter sweep using a simple random search."""
 
+import argparse
 import csv
-import itertools
 import json
 import logging
-import threading
+import math
 import os
+import random
+import threading
 import numpy as np
 import torch
+import yaml
 
 
 from artibot.environment import ensure_dependencies
 from artibot.utils.torch_threads import set_threads
 from artibot.dataset import load_csv_hourly, HourlyDataset
-from artibot.ensemble import EnsembleModel, reject_if_risky
+from artibot.ensemble import EnsembleModel
 from artibot.hyperparams import HyperParams, IndicatorHyperparams
 from artibot.training import csv_training_thread
 from artibot.backtest import robust_backtest
 from artibot.utils import get_device, setup_logging
 
 
+def _log_uniform(lo: float, hi: float) -> float:
+    return math.exp(random.uniform(math.log(lo), math.log(hi)))
+
+
+def _sample_axes(axes: dict) -> dict:
+    out = {}
+    for k, v in axes.items():
+        if v.get("sampling") == "log_uniform":
+            out[k] = _log_uniform(float(v["min"]), float(v["max"]))
+        elif v.get("sampling") == "dirichlet":
+            out[k] = np.random.dirichlet(np.ones(3)).tolist()
+        elif "choices" in v:
+            out[k] = random.choice(v["choices"])
+    return out
+
+
 def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config-file", default="config/hyperparams.yaml")
+    args = parser.parse_args()
+
     setup_logging()
     set_threads(int(os.environ.get("OMP_NUM_THREADS", os.cpu_count() or 1)))
     ensure_dependencies()
     data = load_csv_hourly("Gemini_BTCUSD_1h.csv")[-720:]
+    with open(args.config_file, "r") as f:
+        axes = yaml.safe_load(f).get("experiment_axes", {})
+
+    params = _sample_axes(axes)
+    seq_len = int(params.get("window_length", 24))
     indicator_hp = IndicatorHyperparams(
         rsi_period=14, sma_period=10, macd_fast=12, macd_slow=26, macd_signal=9
     )
     ds_tmp = HourlyDataset(
         data,
-        seq_len=24,
+        seq_len=seq_len,
         indicator_hparams=indicator_hp,
         atr_threshold_k=getattr(indicator_hp, "atr_threshold_k", 1.5),
         train_mode=False,
     )
     n_features = ds_tmp[0][0].shape[1]
-    lrs = [1e-4, 5e-5, 1e-5]
-    mults = [1.5, 2.0, 2.5]
-    rows = []
-    for lr, sl_m, tp_m in itertools.product(lrs, mults, mults):
-        ensemble = EnsembleModel(
-            device=get_device(),
-            n_models=1,
-            lr=lr,
-            weight_decay=1e-4,
-            n_features=n_features,
-            total_steps=2000,
-            grad_accum_steps=4,
-        )
-        ensemble.indicator_hparams = indicator_hp
-        ensemble.hp = HyperParams(indicator_hp=indicator_hp)
-        if hasattr(torch, "set_float32_matmul_precision"):
-            torch.set_float32_matmul_precision("high")
-        if hasattr(torch, "compile"):
-            ensemble.models = [torch.compile(m) for m in ensemble.models]
-        import artibot.globals as G
+    lr = float(params.get("learning_rate", 1e-4))
+    entropy_beta = float(params.get("entropy_beta", 5e-4))
 
-        G.global_SL_multiplier = sl_m
-        G.global_TP_multiplier = tp_m
-        stop = threading.Event()
+    rows = []
+    ensemble = EnsembleModel(
+        device=get_device(),
+        n_models=1,
+        lr=lr,
+        weight_decay=1e-4,
+        n_features=n_features,
+        total_steps=2000,
+        grad_accum_steps=4,
+    )
+    ensemble.indicator_hparams = indicator_hp
+    ensemble.hp = HyperParams(indicator_hp=indicator_hp)
+    if hasattr(torch, "set_float32_matmul_precision"):
+        torch.set_float32_matmul_precision("high")
+    if hasattr(torch, "compile"):
+        ensemble.models = [torch.compile(m) for m in ensemble.models]
+
+    stop = threading.Event()
+    neg_streak = 0
+    best_ckpts: list[tuple[float, str]] = []
+    epoch = 0
+    while epoch < 10:
         csv_training_thread(
             ensemble,
             data,
             stop,
             {"ADAPT_TO_LIVE": False},
             use_prev_weights=False,
-            max_epochs=10,
+            max_epochs=1,
         )
         result = robust_backtest(ensemble, data)
-        attn_entropy = (
-            float(np.mean(G.global_attention_entropy_history[-100:]))
-            if G.global_attention_entropy_history
-            else 0.0
-        )
-        if reject_if_risky(
-            result["sharpe"],
-            result["max_drawdown"],
-            attn_entropy,
-        ):
-            continue
-        rows.append(
-            {
-                "lr": lr,
-                "sl_mult": sl_m,
-                "tp_mult": tp_m,
-                "reward": result["composite_reward"],
-                "mean_sharpe": result["sharpe"],
-                "max_drawdown": result["max_drawdown"],
-                "attn_entropy": attn_entropy,
-            }
-        )
+        sharpe = result.get("sharpe", 0.0)
+        reward = result.get("composite_reward", 0.0)
+        ckpt_path = f"sweeps/ckpt_{epoch}.pth"
+        torch.save(ensemble.models[0].state_dict(), ckpt_path)
+        best_ckpts.append((reward, ckpt_path))
+        best_ckpts.sort(key=lambda x: x[0], reverse=True)
+        best_ckpts = best_ckpts[:3]
+        if sharpe < 0:
+            neg_streak += 1
+        else:
+            neg_streak = 0
+        if neg_streak >= 3:
+            break
+        epoch += 1
+
+    rows.append(
+        {
+            "lr": lr,
+            "entropy_beta": entropy_beta,
+            "reward": best_ckpts[0][0] if best_ckpts else 0.0,
+            "sharpe": sharpe,
+        }
+    )
     os.makedirs("sweeps", exist_ok=True)
     out_path = "sweeps/results.csv"
     with open(out_path, "w", newline="") as f:
         writer = csv.DictWriter(
             f,
-            fieldnames=[
-                "lr",
-                "sl_mult",
-                "tp_mult",
-                "reward",
-                "mean_sharpe",
-                "max_drawdown",
-                "attn_entropy",
-            ],
+            fieldnames=["lr", "entropy_beta", "reward", "sharpe"],
         )
         writer.writeheader()
         writer.writerows(rows)


### PR DESCRIPTION
## Summary
- add experiment axes YAML
- randomise entropy beta in meta agent
- skip risk checks during first few epochs
- rewrite sweep launcher for config sampling and early stop
- document sweep usage in README

## Testing
- `pre-commit run --files scripts/sweep.py artibot/rl.py artibot/training.py README.md config/hyperparams.yaml`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686c59d2a51c832488bec4f5211a5e4e