### PR TITLE
Add flash attention benchmark and sweep utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,12 +163,13 @@ stop‑loss/take‑profit parameters and ATR threshold:
 }
 ```
 
-### Window-Length & Hyperparameter Sweep
+### Hyperparameter Sweep
 
 Define `experiment_axes` in your config YAML and run:
 
 ```bash
-python scripts/sweep.py --config-file config/hyperparams.yaml
+export FLASH_SDP_AUTO_INSTALL=1
+python scripts/sweep.py --config config/hyperparams.yaml --early_stop_epochs 3 --top_k 3
 ```
 
 ## Usage

--- a/artibot/__init__.py
+++ b/artibot/__init__.py
@@ -7,7 +7,14 @@ the installer ran once on first launch.
 
 # ruff: noqa: E402
 from .environment import ensure_dependencies
-from .core.device import check_cuda
+
+try:
+    from .core.device import check_cuda
+except Exception:  # pragma: no cover - optional torch missing
+
+    def check_cuda() -> None:
+        pass
+
 
 ensure_dependencies()  # run the installer once at import time
 check_cuda()

--- a/artibot/feature_ingest.py
+++ b/artibot/feature_ingest.py
@@ -37,9 +37,9 @@ _LOG = logging.getLogger("feature_ingest")
 def ingest_features(df: pd.DataFrame) -> pd.DataFrame:
     """Forward-fill missing values and add a feature mask column."""
 
-    mask = ~df.isna()
+    valid_mask = ~df.isna()
     df = df.ffill(limit=7)
-    df["feature_mask"] = mask.all(axis=1).astype(int)
+    df["feature_mask"] = valid_mask.all(axis=1).astype(int)
     return df
 
 

--- a/artibot/training.py
+++ b/artibot/training.py
@@ -19,7 +19,6 @@ from .utils import heartbeat
 from .feature_manager import enforce_feature_dim
 from artibot.hyperparams import RISK_FILTER
 from artibot.utils.reward_utils import ema, differential_sharpe
-import pandas as pd
 
 import sys
 import json
@@ -280,13 +279,9 @@ def csv_training_thread(
             ret_val = G.global_backtest_profit[-1] if G.global_backtest_profit else 0.0
             returns_series.append(float(ret_val))
 
-            trade_term = ema(
-                torch.tensor(trade_count_series, dtype=torch.float32), tau=96
-            )[-1].item()
-            days_term = ema(
-                torch.tensor(days_in_profit_series, dtype=torch.float32), tau=96
-            )[-1].item()
-            sharpe_term = differential_sharpe(pd.Series(returns_series))
+            trade_term = ema(torch.tensor(trade_count_series), tau=96.0)[-1]
+            days_term = ema(torch.tensor(days_in_profit_series), tau=96.0)[-1]
+            sharpe_term = differential_sharpe(torch.tensor(returns_series))
             ensemble.reward_loss_weight = min(
                 ensemble.max_reward_loss_weight,
                 ensemble.reward_loss_weight + 0.01,

--- a/scripts/flash_benchmark.py
+++ b/scripts/flash_benchmark.py
@@ -1,0 +1,27 @@
+import torch
+from torch.profiler import profile, schedule, tensorboard_trace_handler
+from artibot.dataset import HourlyDataset
+from artibot.ensemble import TradingModel
+
+
+def benchmark(model, loader, label):
+    with profile(
+        schedule=schedule(wait=1, warmup=1, active=3),
+        on_trace_ready=tensorboard_trace_handler(f"./logs/{label}"),
+        record_shapes=True,
+    ) as prof:
+        for batch in loader:
+            model(**batch)
+    print(prof.key_averages().table(sort_by="self_cuda_time_total"))
+
+
+if __name__ == "__main__":
+    ds = HourlyDataset("data.csv")
+    loader = torch.utils.data.DataLoader(
+        ds, batch_size=32, pin_memory=True, num_workers=4
+    )
+    model = TradingModel().cuda()
+    torch.backends.cuda.enable_flash_sdp(False)
+    benchmark(model, loader, "default")
+    torch.backends.cuda.enable_flash_sdp(True)
+    benchmark(model, loader, "flash_sdp")

--- a/scripts/sweep.py
+++ b/scripts/sweep.py
@@ -1,138 +1,41 @@
-#!/usr/bin/env python3
-"""Hyperparameter sweep using a simple random search."""
-
-import argparse
-import csv
-import json
-import logging
-import math
-import os
-import random
-import threading
-import numpy as np
-import torch
 import yaml
+import math
+import random
+import shutil
+from pathlib import Path
+from artibot.run_artibot import main_train
 
 
-from artibot.environment import ensure_dependencies
-from artibot.utils.torch_threads import set_threads
-from artibot.dataset import load_csv_hourly, HourlyDataset
-from artibot.ensemble import EnsembleModel
-from artibot.hyperparams import HyperParams, IndicatorHyperparams
-from artibot.training import csv_training_thread
-from artibot.backtest import robust_backtest
-from artibot.utils import get_device, setup_logging
+def sample_params(axes):
+    params = {}
+    for name, spec in axes.items():
+        if spec.get("sampling") == "log_uniform":
+            params[name] = 10 ** random.uniform(
+                math.log10(spec["min"]), math.log10(spec["max"])
+            )
+        elif spec.get("sampling") == "dirichlet":
+            import numpy as np
 
-
-def _log_uniform(lo: float, hi: float) -> float:
-    return math.exp(random.uniform(math.log(lo), math.log(hi)))
-
-
-def _sample_axes(axes: dict) -> dict:
-    out = {}
-    for k, v in axes.items():
-        if v.get("sampling") == "log_uniform":
-            out[k] = _log_uniform(float(v["min"]), float(v["max"]))
-        elif v.get("sampling") == "dirichlet":
-            out[k] = np.random.dirichlet(np.ones(3)).tolist()
-        elif "choices" in v:
-            out[k] = random.choice(v["choices"])
-    return out
-
-
-def main() -> None:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--config-file", default="config/hyperparams.yaml")
-    args = parser.parse_args()
-
-    setup_logging()
-    set_threads(int(os.environ.get("OMP_NUM_THREADS", os.cpu_count() or 1)))
-    ensure_dependencies()
-    data = load_csv_hourly("Gemini_BTCUSD_1h.csv")[-720:]
-    with open(args.config_file, "r") as f:
-        axes = yaml.safe_load(f).get("experiment_axes", {})
-
-    params = _sample_axes(axes)
-    seq_len = int(params.get("window_length", 24))
-    indicator_hp = IndicatorHyperparams(
-        rsi_period=14, sma_period=10, macd_fast=12, macd_slow=26, macd_signal=9
-    )
-    ds_tmp = HourlyDataset(
-        data,
-        seq_len=seq_len,
-        indicator_hparams=indicator_hp,
-        atr_threshold_k=getattr(indicator_hp, "atr_threshold_k", 1.5),
-        train_mode=False,
-    )
-    n_features = ds_tmp[0][0].shape[1]
-    lr = float(params.get("learning_rate", 1e-4))
-    entropy_beta = float(params.get("entropy_beta", 5e-4))
-
-    rows = []
-    ensemble = EnsembleModel(
-        device=get_device(),
-        n_models=1,
-        lr=lr,
-        weight_decay=1e-4,
-        n_features=n_features,
-        total_steps=2000,
-        grad_accum_steps=4,
-    )
-    ensemble.indicator_hparams = indicator_hp
-    ensemble.hp = HyperParams(indicator_hp=indicator_hp)
-    if hasattr(torch, "set_float32_matmul_precision"):
-        torch.set_float32_matmul_precision("high")
-    if hasattr(torch, "compile"):
-        ensemble.models = [torch.compile(m) for m in ensemble.models]
-
-    stop = threading.Event()
-    neg_streak = 0
-    best_ckpts: list[tuple[float, str]] = []
-    epoch = 0
-    while epoch < 10:
-        csv_training_thread(
-            ensemble,
-            data,
-            stop,
-            {"ADAPT_TO_LIVE": False},
-            use_prev_weights=False,
-            max_epochs=1,
-        )
-        result = robust_backtest(ensemble, data)
-        sharpe = result.get("sharpe", 0.0)
-        reward = result.get("composite_reward", 0.0)
-        ckpt_path = f"sweeps/ckpt_{epoch}.pth"
-        torch.save(ensemble.models[0].state_dict(), ckpt_path)
-        best_ckpts.append((reward, ckpt_path))
-        best_ckpts.sort(key=lambda x: x[0], reverse=True)
-        best_ckpts = best_ckpts[:3]
-        if sharpe < 0:
-            neg_streak += 1
+            params[name] = np.random.dirichlet([1] * len(spec.get("weights", [1])))
         else:
-            neg_streak = 0
-        if neg_streak >= 3:
-            break
-        epoch += 1
-
-    rows.append(
-        {
-            "lr": lr,
-            "entropy_beta": entropy_beta,
-            "reward": best_ckpts[0][0] if best_ckpts else 0.0,
-            "sharpe": sharpe,
-        }
-    )
-    os.makedirs("sweeps", exist_ok=True)
-    out_path = "sweeps/results.csv"
-    with open(out_path, "w", newline="") as f:
-        writer = csv.DictWriter(
-            f,
-            fieldnames=["lr", "entropy_beta", "reward", "sharpe"],
-        )
-        writer.writeheader()
-        writer.writerows(rows)
-    logging.info(json.dumps({"results_file": out_path}))
+            params[name] = random.choice(spec["choices"])
+    return params
 
 
 if __name__ == "__main__":
-    main()
+    import argparse
+
+    p = argparse.ArgumentParser()
+    p.add_argument("--config", required=True)
+    p.add_argument("--early_stop_epochs", type=int, default=3)
+    p.add_argument("--top_k", type=int, default=3)
+    args = p.parse_args()
+
+    axes = yaml.safe_load(Path(args.config).read_text())["experiment_axes"]
+    results = []
+    for _ in range(20):
+        params = sample_params(axes)
+        res = main_train(**params, early_stop=args.early_stop_epochs)
+        results.append((res["sharpe"], res["checkpoint_path"]))
+    for _, ckpt in sorted(results, key=lambda x: -x[0])[: args.top_k]:
+        shutil.copy(ckpt, Path("best") / Path(ckpt).name)


### PR DESCRIPTION
## Summary
- auto-install FlashAttention kernels at import time
- add exponential moving average helpers
- record reward-related metrics in training
- expose hyperparameter sweep script and benchmark script
- document sweep usage

## Testing
- `pre-commit run --files artibot/__init__.py artibot/core/device.py artibot/feature_ingest.py artibot/rl.py artibot/training.py artibot/utils/reward_utils.py scripts/sweep.py scripts/flash_benchmark.py README.md tests/test_device_flash_auto_install.py artibot/gui_v2.py`

------
https://chatgpt.com/codex/tasks/task_e_686c6a5fb75883249fc8fb7fa15d53d0