### PR TITLE
Enable auto install extras & compile model

### DIFF
--- a/artibot/core/device.py
+++ b/artibot/core/device.py
@@ -15,7 +15,13 @@ def ensure_dependencies() -> None:
     if os.environ.get("ARTIBOT_SKIP_INSTALL") == "1":
         return
 
-    pkgs = ["optuna", "pandas"]
+    pkgs = [
+        "optuna",
+        "pandas",
+        "torchmetrics",
+        "torchvision",
+        "tensorboard",
+    ]
     for pkg in pkgs:
         try:
             __import__(pkg)

--- a/artibot/model.py
+++ b/artibot/model.py
@@ -13,6 +13,11 @@ from .dataset import TradeParams
 from .utils import attention_entropy
 
 
+def _ver_tuple(ver: str) -> tuple[int, int]:
+    major, minor, *_ = ver.split(".")
+    return int(major), int(minor)
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -150,6 +155,21 @@ class TradingTransformer(TradingModel):
     """Backward-compatible alias for :class:`TradingModel`."""
 
     pass
+
+
+###############################################################################
+
+
+def build_model(*args, **kwargs) -> TradingModel:
+    """Return a ``TradingModel`` compiled on PyTorch 2+."""
+
+    model = TradingModel(*args, **kwargs)
+    if hasattr(torch, "compile") and _ver_tuple(torch.__version__) >= (2, 0):
+        try:  # pragma: no cover - optional feature
+            model = torch.compile(model)  # type: ignore[arg-type]
+        except Exception as exc:  # pragma: no cover - compile may fail
+            logger.info("torch.compile failed: %s", exc)
+    return model
 
 
 ###############################################################################


### PR DESCRIPTION
## Summary
- auto install torchmetrics, torchvision and tensorboard
- add `build_model()` helper that calls `torch.compile`

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686dbba1834c83248b761b7f65cdc7e0