### PR TITLE
Improve GUI stability

### DIFF
--- a/artibot/bot_app.py
+++ b/artibot/bot_app.py
@@ -214,7 +214,7 @@ def run_bot(max_epochs: int | None = None, *, overfit_toy: bool = False) -> None
             max_epochs,
             weights_path,
         ),
-        kwargs={"debug_anomaly": __debug__, "overfit_toy": overfit_toy},
+        kwargs={"debug_anomaly": overfit_toy, "overfit_toy": overfit_toy},
         daemon=True,
     )
     train_th.start()
@@ -255,6 +255,8 @@ def run_bot(max_epochs: int | None = None, *, overfit_toy: bool = False) -> None
         root.mainloop()
     except KeyboardInterrupt:
         pass
+    except Exception as exc:  # pragma: no cover - unexpected GUI error
+        logging.exception("Tkinter mainloop failed: %s", exc)
 
     stop_event.set()
     threads = [

--- a/artibot/gui_v2.py
+++ b/artibot/gui_v2.py
@@ -678,7 +678,9 @@ class TradingGUI:
         if val_x:
             self.ax_loss.plot(val_x, val_y, label="Val", marker="x")
         self.ax_loss.set_title("Loss")
-        self.ax_loss.legend()
+        handles, labels = self.ax_loss.get_legend_handles_labels()
+        if labels:
+            self.ax_loss.legend(handles, labels)
         self.loss_comment_label.config(text=self._loss_comment())
 
         self.ax_equity.clear()
@@ -694,7 +696,9 @@ class TradingGUI:
             ts_dt = [_dt.datetime.fromtimestamp(t) for t in ts]
 
             self.ax_equity.plot(ts_dt, bal, color="green", label="Best")
-        self.ax_equity.legend()
+        handles, labels = self.ax_equity.get_legend_handles_labels()
+        if labels:
+            self.ax_equity.legend(handles, labels)
 
         # Attention
         self.ax_attention.clear()
@@ -755,7 +759,9 @@ class TradingGUI:
         self.ax_tl.set_ylim(-0.5, 7.5)
         self.ax_tl.set_yticks([])
         if idx > 0:
-            self.ax_tl.legend(ncol=4, fontsize=6, framealpha=0.3)
+            handles, labels = self.ax_tl.get_legend_handles_labels()
+            if labels:
+                self.ax_tl.legend(handles, labels, ncol=4, fontsize=6, framealpha=0.3)
         self.ax_tl.set_title("Indicators / Trade")
         self.canvas_tl.draw()
 

--- a/run_artibot.py
+++ b/run_artibot.py
@@ -325,7 +325,7 @@ def main() -> None:
             None,
             weights_path,
         ),
-        kwargs={"debug_anomaly": __debug__, "init_event": init_done},
+        kwargs={"debug_anomaly": dev_mode, "init_event": init_done},
         daemon=True,
     )
     train_th.start()
@@ -401,6 +401,8 @@ def main() -> None:
         root.mainloop()
     except KeyboardInterrupt:
         pass
+    except Exception as exc:  # pragma: no cover - unexpected GUI error
+        logging.exception("Tkinter mainloop failed: %s", exc)
 
     stop_event.set()
     for th in (train_th, live_feed_th, meta_th, validate_th):


### PR DESCRIPTION
## Summary
- log unexpected Tkinter crashes in `run_artibot` and `bot_app`
- disable autograd anomaly detection unless `--dev` or `--overfit_toy`
- avoid 'No artists with labels' warnings in `gui_v2`

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: AttributeError: 'types.SimpleNamespace' object)*

------
https://chatgpt.com/codex/tasks/task_e_686dc278932883249a5a0956bff55dc9