### PR TITLE
Fix autoinstall order and skip CUDA

### DIFF
--- a/artibot/__init__.py
+++ b/artibot/__init__.py
@@ -8,6 +8,11 @@ the installer ran once on first launch.
 # ruff: noqa: E402
 from .environment import ensure_dependencies
 
+# Make sure third‑party packages like ``torch`` are present before importing
+# modules that rely on them.  This mirrors the behavior of the original
+# single‑file script where packages were installed on first launch.
+ensure_dependencies()  # run the installer once at import time
+
 try:
     from .core.device import check_cuda
 except Exception:  # pragma: no cover - optional torch missing
@@ -16,7 +21,6 @@ except Exception:  # pragma: no cover - optional torch missing
         pass
 
 
-ensure_dependencies()  # run the installer once at import time
 check_cuda()
 from config import FEATURE_CONFIG
 from .constants import FEATURE_DIMENSION

--- a/artibot/core/device.py
+++ b/artibot/core/device.py
@@ -107,6 +107,18 @@ def _have_cuda() -> bool:
 def _install_cuda() -> None:
     if _have_cuda():
         return
+    try:
+        if (
+            subprocess.call(
+                ["nvidia-smi"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+            )
+            != 0
+        ):
+            log.info("No NVIDIA driver detected; skipping CUDA wheel install.")
+            return
+    except Exception:
+        log.info("No NVIDIA driver detected; skipping CUDA wheel install.")
+        return
     cmd = [
         sys.executable,
         "-m",


### PR DESCRIPTION
## Summary
- ensure optional dependencies install before importing torch
- avoid CUDA wheel install when nvidia drivers are absent

## Testing
- `pre-commit run --all-files`
- `pytest tests/test_device.py::test_get_device -q`


------
https://chatgpt.com/codex/tasks/task_e_686e3ef6292c8324bcbfa8f89e8696c5