### PR TITLE
Use zero workers by default

### DIFF
--- a/artibot/training.py
+++ b/artibot/training.py
@@ -221,7 +221,7 @@ def csv_training_thread(
             with_scaled=True,
         )
 
-        workers = int(config.get("NUM_WORKERS", G.cpu_limit))
+        workers = int(config.get("NUM_WORKERS", 0))
         logging.info(
             "DATALOADER", extra={"workers": workers, "device": ensemble.device.type}
         )


### PR DESCRIPTION
## Summary
- adjust the default DataLoader worker count to avoid issues on Windows

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686ed82b386c83248efeb3990fdb6a9a