### PR TITLE
Fix Optuna objective to use composite_reward

### DIFF
--- a/artibot/training.py
+++ b/artibot/training.py
@@ -842,7 +842,7 @@ def objective(trial: optuna.trial.Trial) -> float:
         update_globals=False,
     )
     metrics = robust_backtest(model, data)
-    return -metrics.get("sharpe", 0.0)
+    return -metrics.get("composite_reward", 0.0)
 
 
 def run_hpo() -> dict:


### PR DESCRIPTION
## Summary
- return `composite_reward` metric in Optuna objective

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686ed83e00b88324a9a24e131cc948c2