### PR TITLE
Fix NEW_BEST logging spam at epoch 0

### DIFF
--- a/artibot/ensemble.py
+++ b/artibot/ensemble.py
@@ -704,12 +704,13 @@ class EnsembleModel(nn.Module):
                 initial_balance=100.0,
             )
             G.global_best_monthly_stats_table = best_monthly
-            update_best(
-                self.train_steps,
-                cur_reward,
-                current_result["net_pct"],
-                self.weights_path,
-            )
+            if self.train_steps > 0:
+                update_best(
+                    self.train_steps,
+                    cur_reward,
+                    current_result["net_pct"],
+                    self.weights_path,
+                )
 
         mean_ent = float(torch.tensor(self.entropies).mean()) if self.entropies else 0.0
         mean_mp = float(torch.tensor(self.max_probs).mean()) if self.max_probs else 0.0

--- a/tests/test_new_best_logging.py
+++ b/tests/test_new_best_logging.py
@@ -78,6 +78,9 @@ def test_new_best_logging(monkeypatch, caplog):
     G.global_sharpe = 1.2
     G.global_max_drawdown = -0.1
 
+    # Skip epoch 0 spam by starting after the first step
+    ens.train_steps = 1
+
     caplog.set_level(logging.INFO)
     ens.train_one_epoch(dl, dl, [])
 


### PR DESCRIPTION
## Summary
- avoid logging NEW_BEST at the initialization step
- update the NEW_BEST test accordingly

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68704446a1848324a3c1b89e0698d950