### PR TITLE
Fix GUI best model display

### DIFF
--- a/artibot/ensemble.py
+++ b/artibot/ensemble.py
@@ -358,6 +358,16 @@ class EnsembleModel(nn.Module):
         if update_globals and current_result["composite_reward"] > best:
             G.global_best_composite_reward = current_result["composite_reward"]
             G.global_best_sharpe = max(G.global_best_sharpe, current_result["sharpe"])
+            G.global_best_equity_curve = current_result["equity_curve"]
+            G.global_best_drawdown = current_result["max_drawdown"]
+            G.global_best_net_pct = current_result["net_pct"]
+            G.global_best_num_trades = current_result["trades"]
+            G.global_best_win_rate = current_result["win_rate"]
+            G.global_best_profit_factor = current_result["profit_factor"]
+            G.global_best_avg_win = current_result.get("avg_win", 0.0)
+            G.global_best_avg_loss = current_result.get("avg_loss", 0.0)
+            G.global_best_inactivity_penalty = current_result["inactivity_penalty"]
+            G.global_best_days_in_profit = current_result["days_in_profit"]
             self.best_state_dicts = [m.state_dict() for m in self.models]
             self.save_best_weights(self.weights_path)
             md5 = ""

--- a/artibot/gui_v2.py
+++ b/artibot/gui_v2.py
@@ -677,6 +677,12 @@ class TradingGUI:
             val_y = pd.Series(val_y).ewm(span=10).mean().tolist()
         if val_x:
             self.ax_loss.plot(val_x, val_y, label="Val", marker="x")
+
+        all_losses = train_vals + val_y
+        if all_losses:
+            self.ax_loss.set_ylim(min(all_losses), max(all_losses))
+            self.ax_loss.relim()
+            self.ax_loss.autoscale_view()
         self.ax_loss.set_title("Loss")
         handles, labels = self.ax_loss.get_legend_handles_labels()
         if labels:


### PR DESCRIPTION
## Summary
- keep "Best Stats" updated when promoting composite reward
- autoscale the loss plot so validation is visible

## Testing
- `pre-commit run --files artibot/gui_v2.py artibot/ensemble.py`
- `pytest -q --no-heavy tests/test_state.py`


------
https://chatgpt.com/codex/tasks/task_e_6870443b0e4083248e4aa0ace047f726