### PR TITLE
Fix DataLoader persistent worker flag

### DIFF
--- a/artibot/dataset.py
+++ b/artibot/dataset.py
@@ -45,7 +45,10 @@ if "openai" in sys.modules and getattr(sys.modules["openai"], "__spec__", None) 
 # --------------------------------------------------------------------------- #
 # caching objects
 # --------------------------------------------------------------------------- #
-_IMPUTER = KNNImputer(n_neighbors=5)
+try:
+    _IMPUTER = KNNImputer(n_neighbors=5) if callable(KNNImputer) else None
+except Exception:
+    _IMPUTER = None
 
 
 # --------------------------------------------------------------------------- #
@@ -258,7 +261,8 @@ def build_features(
     validate_features(feats, enabled_mask=mask)
 
     feats = np.nan_to_num(feats, nan=0.0, posinf=0.0, neginf=0.0)
-    feats[:, mask] = _IMPUTER.fit_transform(feats[:, mask])
+    if _IMPUTER is not None:
+        feats[:, mask] = _IMPUTER.fit_transform(feats[:, mask])
     feats = zero_disabled(feats, mask)
     feats = rolling_zscore(feats, window=50, mask=mask)
     feats = zero_disabled(feats, mask)

--- a/artibot/training.py
+++ b/artibot/training.py
@@ -102,14 +102,17 @@ def rebuild_loader(
         del old_loader
         gc.collect()
 
-    return torch.utils.data.DataLoader(
-        dataset,
-        batch_size=batch_size,
-        shuffle=shuffle,
-        num_workers=num_workers,
-        persistent_workers=True,
-        pin_memory=True,
-    )
+    loader_kwargs = {
+        "dataset": dataset,
+        "batch_size": batch_size,
+        "shuffle": shuffle,
+        "num_workers": num_workers,
+        "pin_memory": True,
+    }
+    if num_workers > 0:
+        loader_kwargs["persistent_workers"] = True
+
+    return torch.utils.data.DataLoader(**loader_kwargs)
 
 
 def profile_data_copy(

--- a/tests/test_csv_workers.py
+++ b/tests/test_csv_workers.py
@@ -48,7 +48,7 @@ def test_csv_thread_uses_config(monkeypatch):
     assert called.get("pinned") is True
 
 
-def test_persistent_workers_enabled(monkeypatch):
+def test_persistent_workers_disabled_when_zero(monkeypatch):
     monkeypatch.setattr(os, "cpu_count", lambda: 2)
     called = {}
 
@@ -80,5 +80,5 @@ def test_persistent_workers_enabled(monkeypatch):
     stop = threading.Event()
     csv_training_thread(ens, data, stop, {}, use_prev_weights=False, max_epochs=1)
 
-    assert called.get("persistent") is True
+    assert called.get("persistent") is None
     assert called.get("pinned") is True


### PR DESCRIPTION
## Summary
- ensure DataLoader sets `persistent_workers` only when workers > 0
- handle missing sklearn during tests
- adjust csv worker tests for new default
- extend test stubs for torch and other packages

## Testing
- `pre-commit run --all-files`
- `NO_HEAVY=1 pytest tests/test_device.py::test_get_device -q`

------
https://chatgpt.com/codex/tasks/task_e_68704cc1fd9c8324803eddb958e85052