### PR TITLE
Add gradient debug logging

### DIFF
--- a/artibot/ensemble.py
+++ b/artibot/ensemble.py
@@ -437,12 +437,15 @@ class EnsembleModel(nn.Module):
                     )
 
                 losses = []
+                ce_vals: list[float] = []
+                r_vals: list[float] = []
                 with ctx, torch.autograd.set_detect_anomaly(True):
                     for model in self.models:
                         logits, _, pred_reward = model(bx.clone())
                         self.entropies.append(getattr(model, "last_entropy", 0.0))
                         self.max_probs.append(getattr(model, "last_max_prob", 0.0))
                         ce_loss = self.criterion(logits, by)
+                        ce_vals.append(float(ce_loss))
                         if not torch.isfinite(pred_reward).all():
                             logging.error(
                                 "Non‑finite pred_reward detected at step %s",
@@ -462,6 +465,7 @@ class EnsembleModel(nn.Module):
                             )
                         else:
                             r_loss = torch.tensor(0.0, device=self.device)
+                        r_vals.append(float(r_loss))
                         loss = ce_loss + self.reward_loss_weight * r_loss
                         if not torch.isfinite(loss).all():
                             logging.error(
@@ -478,6 +482,8 @@ class EnsembleModel(nn.Module):
                 if not losses:
                     continue
 
+                debug_ce = float(np.mean(ce_vals)) if ce_vals else 0.0
+                debug_r = float(np.mean(r_vals)) if r_vals else 0.0
                 total_batch_loss = torch.stack(losses).sum() / self.grad_accum_steps
                 self.scaler.scale(total_batch_loss).backward()
 
@@ -487,6 +493,16 @@ class EnsembleModel(nn.Module):
                         zip(self.models, self.optimizers)
                     ):
                         self.scaler.unscale_(opt_)
+                        if idx_m == 0:
+                            g = model.fc.weight.grad
+                            g_norm = g.abs().mean().item() if g is not None else 0.0
+                            logging.debug(
+                                "GRAD_CHECK step=%d ce_loss=%.6f r_loss=%.6f grad=%.6f",
+                                self.train_steps,
+                                debug_ce,
+                                debug_r,
+                                g_norm,
+                            )
                         torch.nn.utils.clip_grad_norm_(
                             self.models[idx_m].parameters(), 1.0
                         )


### PR DESCRIPTION
## Summary
- log CrossEntropy and reward losses during training
- print gradient magnitude for `fc.weight` to verify reward gradient flow

## Testing
- `pre-commit run --files artibot/ensemble.py`
- `pytest -q` *(fails: 19 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6875023721f883248f5814cc9bb2d8cf