### PR TITLE
Expand backtest exploration

### DIFF
--- a/artibot/ensemble.py
+++ b/artibot/ensemble.py
@@ -6,6 +6,7 @@ import inspect
 from contextlib import nullcontext
 from typing import Iterable, Optional, Tuple
 from threading import Event
+from itertools import product
 import threading
 import logging
 import random
@@ -310,7 +311,157 @@ class EnsembleModel(nn.Module):
         """
         # mutate shared state on the globals module
 
-        current_result = robust_backtest(self, data_full, indicators=features)
+        sma_opts = [10, 20]
+        rsi_opts = [9, 14]
+        macd_fast_opts = [12, 16]
+        macd_slow_opts = [26, 30]
+        macd_sig_opts = [9, 12]
+        ema_opts = [20, 50]
+        atr_opts = [14, 21]
+        vortex_opts = [14, 21]
+        cmf_opts = [20, 30]
+        donchian_opts = [20, 30]
+        kijun_opts = [26, 34]
+        tenkan_opts = [9, 12]
+        disp_opts = [26, 52]
+        conf_opts = [self.hp.conf_threshold, self.hp.conf_threshold * 1.5]
+        sl_mults = [1.0, 1.5]
+        tp_mults = [1.0, 1.5]
+
+        param_sets = list(
+            product(
+                sma_opts,
+                rsi_opts,
+                macd_fast_opts,
+                macd_slow_opts,
+                macd_sig_opts,
+                ema_opts,
+                atr_opts,
+                vortex_opts,
+                cmf_opts,
+                donchian_opts,
+                kijun_opts,
+                tenkan_opts,
+                disp_opts,
+                conf_opts,
+                sl_mults,
+                tp_mults,
+            )
+        )
+
+        best_result: dict | None = None
+        best_cfg: dict | None = None
+
+        for cfg in param_sets:
+            (
+                sma_period,
+                rsi_period,
+                macd_fast,
+                macd_slow,
+                macd_sig,
+                ema_period,
+                atr_period,
+                vortex_period,
+                cmf_period,
+                donchian_period,
+                kijun_period,
+                tenkan_period,
+                disp_period,
+                conf,
+                sl_mult,
+                tp_mult,
+            ) = cfg
+
+            self.indicator_hparams.sma_period = sma_period
+            self.indicator_hparams.rsi_period = rsi_period
+            self.indicator_hparams.macd_fast = macd_fast
+            self.indicator_hparams.macd_slow = macd_slow
+            self.indicator_hparams.macd_signal = macd_sig
+            self.indicator_hparams.ema_period = ema_period
+            self.indicator_hparams.atr_period = atr_period
+            self.indicator_hparams.vortex_period = vortex_period
+            self.indicator_hparams.cmf_period = cmf_period
+            self.indicator_hparams.donchian_period = donchian_period
+            self.indicator_hparams.kijun_period = kijun_period
+            self.indicator_hparams.tenkan_period = tenkan_period
+            self.indicator_hparams.displacement = disp_period
+            self.hp.conf_threshold = conf
+            sl = self.hp.sl * sl_mult
+            tp = self.hp.tp * tp_mult
+            G.update_trade_params(sl, tp)
+
+            result = robust_backtest(self, data_full)
+            logging.info(
+                "SWEEP_CFG",
+                extra={
+                    "cfg": {
+                        "sma": sma_period,
+                        "rsi": rsi_period,
+                        "macd_fast": macd_fast,
+                        "macd_slow": macd_slow,
+                        "macd_sig": macd_sig,
+                        "ema": ema_period,
+                        "atr": atr_period,
+                        "vortex": vortex_period,
+                        "cmf": cmf_period,
+                        "donchian": donchian_period,
+                        "kijun": kijun_period,
+                        "tenkan": tenkan_period,
+                        "disp": disp_period,
+                        "conf": conf,
+                        "sl": sl,
+                        "tp": tp,
+                    },
+                    "reward": result.get("composite_reward", 0.0),
+                },
+            )
+
+            if best_result is None or result.get(
+                "composite_reward", 0.0
+            ) > best_result.get(
+                "composite_reward",
+                0.0,
+            ):
+                best_result = result
+                best_cfg = {
+                    "sma": sma_period,
+                    "rsi": rsi_period,
+                    "macd_fast": macd_fast,
+                    "macd_slow": macd_slow,
+                    "macd_sig": macd_sig,
+                    "ema": ema_period,
+                    "atr": atr_period,
+                    "vortex": vortex_period,
+                    "cmf": cmf_period,
+                    "donchian": donchian_period,
+                    "kijun": kijun_period,
+                    "tenkan": tenkan_period,
+                    "disp": disp_period,
+                    "conf": conf,
+                    "sl": sl,
+                    "tp": tp,
+                }
+
+        if best_cfg is not None:
+            self.indicator_hparams.sma_period = best_cfg["sma"]
+            self.indicator_hparams.rsi_period = best_cfg["rsi"]
+            self.indicator_hparams.macd_fast = best_cfg["macd_fast"]
+            self.indicator_hparams.macd_slow = best_cfg["macd_slow"]
+            self.indicator_hparams.macd_signal = best_cfg["macd_sig"]
+            self.indicator_hparams.ema_period = best_cfg["ema"]
+            self.indicator_hparams.atr_period = best_cfg["atr"]
+            self.indicator_hparams.vortex_period = best_cfg["vortex"]
+            self.indicator_hparams.cmf_period = best_cfg["cmf"]
+            self.indicator_hparams.donchian_period = best_cfg["donchian"]
+            self.indicator_hparams.kijun_period = best_cfg["kijun"]
+            self.indicator_hparams.tenkan_period = best_cfg["tenkan"]
+            self.indicator_hparams.displacement = best_cfg["disp"]
+            self.hp.conf_threshold = best_cfg["conf"]
+            G.update_trade_params(best_cfg["sl"], best_cfg["tp"])
+
+        current_result = best_result or robust_backtest(
+            self, data_full, indicators=features
+        )
         if data_full:
             assert len(data_full[0]) >= 5, "Expect raw OHLCV rows"
 

--- a/artibot/utils/heartbeat.py
+++ b/artibot/utils/heartbeat.py
@@ -22,7 +22,7 @@ try:
 
     nvmlInit()
     _NVML = True
-except ImportError:  # pragma: no cover - optional dep
+except Exception:  # pragma: no cover - optional dep or missing library
     _NVML = False
 
 _HANDLE = None


### PR DESCRIPTION
## Summary
- sweep indicator periods, thresholds and trade params
- log each configuration and reward
- include more indicators in sweep

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: 17 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68759b4461588324b0d7983b2b1ab116