### PR TITLE
Allow training before sentiment backfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,8 @@ and profit factor exceed the configured thresholds.  On recent
 versions you'll also be prompted to **skip the historical sentiment
 pull** if GDELT is slow. Answer `yes` to set the environment variable
 `NO_HEAVY=1` and continue without downloading several gigabytes of
-data.
+data. The backfill now runs in the background so the GUI and training
+start immediately.
 
 Run a short training session without the GUI:
 

--- a/run_artibot.py
+++ b/run_artibot.py
@@ -402,8 +402,8 @@ def main() -> None:
 
         def _bg_init() -> None:
             nonlocal done_sent
+            init_done.set()  # unblock training immediately
             if SKIP_SENTIMENT:
-                init_done.set()
                 if not done_sent:
                     progress_q.put(("DONE", ""))
                     done_sent = True
@@ -414,7 +414,6 @@ def main() -> None:
 
                 _bf.main(progress_cb=lambda pct, msg: progress_q.put((pct, msg)))
             finally:
-                init_done.set()
                 if not done_sent:
                     progress_q.put(("DONE", ""))
                     done_sent = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -251,7 +251,28 @@ def pytest_configure(config):
         req = types.ModuleType("requests")
         req.RequestException = Exception
         req.get = lambda *a, **k: types.SimpleNamespace(json=lambda: {})
+
+        class _DummySession:
+            def __init__(self, *a, **k):
+                pass
+
+            def get(self, *a, **k):
+                return types.SimpleNamespace(json=lambda: {})
+
+        req.Session = _DummySession
+        util_mod = types.SimpleNamespace(default_user_agent=lambda *a, **k: "")
+        req.utils = util_mod
+        exc_mod = types.SimpleNamespace(
+            HTTPError=Exception,
+            Timeout=Exception,
+            TooManyRedirects=Exception,
+            RequestException=Exception,
+            ConnectionError=Exception,
+        )
+        req.exceptions = exc_mod
         sys.modules["requests"] = req
+        sys.modules["requests.utils"] = util_mod
+        sys.modules["requests.exceptions"] = exc_mod
 
     if "matplotlib" not in sys.modules:
         matplotlib = types.ModuleType("matplotlib")


### PR DESCRIPTION
## Summary
- unblock the training thread immediately so the GUI and training can start
- clarify that sentiment backfill runs in the background
- improve tests' requests stub for ccxt

## Testing
- `pre-commit run --all-files`
- `pytest -q tests/test_bootstrap.py::test_splash_handoff --no-heavy`

------
https://chatgpt.com/codex/tasks/task_e_6876a3e60b948324b3e4250f1999f4c8