### PR TITLE
Fix splash race when skipping sentiment

### DIFF
--- a/artibot/ensemble.py
+++ b/artibot/ensemble.py
@@ -357,7 +357,6 @@ class EnsembleModel(nn.Module):
                 )
             )
 
-
             # --- ❷  Sweep the grid --------------------------------------------------------
             for cfg in param_sets:
                 (
@@ -434,7 +433,6 @@ class EnsembleModel(nn.Module):
                 ) > best_result.get("composite_reward", 0.0):
                     best_result = result
                     best_cfg = {
-
                         "sma": sma_period,
                         "rsi": rsi_period,
                         "macd_fast": macd_fast,
@@ -451,9 +449,7 @@ class EnsembleModel(nn.Module):
                         "conf": conf,
                         "sl": sl,
                         "tp": tp,
-
                     }
-
 
         # --- ❸  Re-apply best config & run final back-test ---------------------------
         if best_cfg is not None:

--- a/run_artibot.py
+++ b/run_artibot.py
@@ -278,10 +278,9 @@ def main() -> None:
     live_feed_th: threading.Thread | None = None
     meta_th: threading.Thread | None = None
     validate_th: threading.Thread | None = None
-    done_sent = False
 
     def setup_worker() -> None:
-        nonlocal train_th, live_feed_th, meta_th, validate_th, done_sent
+        nonlocal train_th, live_feed_th, meta_th, validate_th
         from artibot.training import run_hpo
 
         device = get_device()
@@ -331,7 +330,6 @@ def main() -> None:
             ensemble.load_best_weights(weights_path)
 
         progress_q.put(("DONE", ""))
-        done_sent = True
         root.after(
             0,
             lambda: TradingGUI(root, ensemble, weights_path, connector, dev=dev_mode),
@@ -401,12 +399,9 @@ def main() -> None:
         ingest_th.start()
 
         def _bg_init() -> None:
-            nonlocal done_sent
             if SKIP_SENTIMENT:
                 init_done.set()
-                if not done_sent:
-                    progress_q.put(("DONE", ""))
-                    done_sent = True
+                progress_q.put((0.0, "Skipping sentiment pull; continuing…"))
                 return
             progress_q.put((0.0, "Downloading historical sentiment + macro data…"))
             try:
@@ -415,9 +410,6 @@ def main() -> None:
                 _bf.main(progress_cb=lambda pct, msg: progress_q.put((pct, msg)))
             finally:
                 init_done.set()
-                if not done_sent:
-                    progress_q.put(("DONE", ""))
-                    done_sent = True
 
         threading.Thread(target=_bg_init, daemon=True).start()
 


### PR DESCRIPTION
## Summary
- prevent closing splash screen early when skipping sentiment
- apply Black formatting to ensemble module

## Testing
- `pre-commit run --all-files`
- `pytest tests/test_heartbeat.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6876c2889d5483249c915bd23476f1fd