### PR TITLE
Fix GUI validation loss and stats tables

### DIFF
--- a/artibot/ensemble.py
+++ b/artibot/ensemble.py
@@ -509,14 +509,16 @@ class EnsembleModel(nn.Module):
             current_result["trade_details"],
             initial_balance=100.0,
         )
+        logging.info("YEARLY_STATS rows=%d", len(dfy))
         if update_globals:
             G.global_yearly_stats_table = table_str
 
-        _, monthly_table = compute_monthly_stats(
+        dfm, monthly_table = compute_monthly_stats(
             current_result["equity_curve"],
             current_result["trade_details"],
             initial_balance=100.0,
         )
+        logging.info("MONTHLY_STATS rows=%d", len(dfm))
         if update_globals:
             G.global_monthly_stats_table = monthly_table
 


### PR DESCRIPTION
## Summary
- support validation split in `csv_training_thread`
- log monthly/yearly table rows in `EnsembleModel.train_one_epoch`
- plot validation loss even when gaps exist
- show latest monthly/yearly stats if best not available

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psutil')*

------
https://chatgpt.com/codex/tasks/task_e_6877512b3e088324ac35c2258aec5485