### PR TITLE
Fix stats mismatch after loading best model

### DIFF
--- a/artibot/ensemble.py
+++ b/artibot/ensemble.py
@@ -1213,6 +1213,20 @@ class EnsembleModel(nn.Module):
                     G.global_sharpe = loaded_result["sharpe"]
                     G.global_profit_factor = loaded_result["profit_factor"]
                     G.gui_event.set()
+                    G.global_max_drawdown = loaded_result["max_drawdown"]
+                    G.global_net_pct = loaded_result["net_pct"]
+                    G.global_num_trades = loaded_result["trades"]
+                    G.global_win_rate = loaded_result["win_rate"]
+                    G.global_avg_trade_duration = loaded_result["avg_trade_duration"]
+                    G.global_avg_win = loaded_result.get("avg_win", 0.0)
+                    G.global_avg_loss = loaded_result.get("avg_loss", 0.0)
+                    G.global_inactivity_penalty = loaded_result["inactivity_penalty"]
+                    G.global_composite_reward = loaded_result["composite_reward"]
+                    G.global_days_without_trading = loaded_result[
+                        "days_without_trading"
+                    ]
+                    G.global_trade_details = loaded_result["trade_details"]
+                    G.global_days_in_profit = loaded_result["days_in_profit"]
                     G.global_best_equity_curve = loaded_result["equity_curve"]
                     G.global_best_drawdown = loaded_result["max_drawdown"]
                     G.global_best_net_pct = loaded_result["net_pct"]
@@ -1240,6 +1254,7 @@ class EnsembleModel(nn.Module):
                         loaded_result["trade_details"],
                         initial_balance=100.0,
                     )
+                    G.global_yearly_stats_table = best_table
                     G.global_best_yearly_stats_table = best_table
 
                     _, best_monthly = compute_monthly_stats(
@@ -1247,6 +1262,7 @@ class EnsembleModel(nn.Module):
                         loaded_result["trade_details"],
                         initial_balance=100.0,
                     )
+                    G.global_monthly_stats_table = best_monthly
                     G.global_best_monthly_stats_table = best_monthly
             except Exception:
                 pass

--- a/tests/test_best_weights_load.py
+++ b/tests/test_best_weights_load.py
@@ -1,0 +1,73 @@
+# ruff: noqa: E402
+import sys
+import types
+from importlib.machinery import ModuleSpec
+
+for name in ["openai", "ccxt", "tkinter", "tkinter.ttk"]:
+    mod = types.ModuleType(name)
+    mod.__spec__ = ModuleSpec(name, loader=None)
+    sys.modules.setdefault(name, mod)
+
+matplotlib = types.ModuleType("matplotlib")
+matplotlib.use = lambda *a, **k: None
+matplotlib.__spec__ = ModuleSpec("matplotlib", loader=None)
+sys.modules.setdefault("matplotlib", matplotlib)
+pyplot = types.ModuleType("pyplot")
+pyplot.__spec__ = ModuleSpec("pyplot", loader=None)
+sys.modules.setdefault("matplotlib.pyplot", pyplot)
+backend = types.ModuleType("matplotlib.backends.backend_tkagg")
+backend.FigureCanvasTkAgg = object
+backend.__spec__ = ModuleSpec("matplotlib.backends.backend_tkagg", loader=None)
+sys.modules.setdefault("matplotlib.backends.backend_tkagg", backend)
+
+import torch
+import artibot.globals as G
+from artibot.ensemble import EnsembleModel
+
+
+def test_load_best_weights_updates_stats(tmp_path, monkeypatch):
+    ckpt = {"best_composite_reward": 1.0, "state_dicts": [{}]}
+    path = tmp_path / "best.pth"
+    torch.save(ckpt, path)
+
+    def dummy_backtest(*_a, **_k):
+        return {
+            "equity_curve": [(0, 1.0), (1, 2.0)],
+            "net_pct": 123.0,
+            "trades": 4,
+            "sharpe": 1.5,
+            "max_drawdown": -0.2,
+            "trade_details": [],
+            "composite_reward": 5.0,
+            "inactivity_penalty": 0.0,
+            "days_without_trading": 0,
+            "days_in_profit": 1.0,
+            "win_rate": 0.5,
+            "profit_factor": 1.2,
+            "avg_trade_duration": 0.0,
+            "avg_win": 0.1,
+            "avg_loss": -0.05,
+        }
+
+    monkeypatch.setattr("artibot.ensemble.robust_backtest", dummy_backtest)
+    monkeypatch.setattr(
+        "artibot.ensemble.compute_yearly_stats", lambda *a, **k: (None, "")
+    )
+    monkeypatch.setattr(
+        "artibot.ensemble.compute_monthly_stats", lambda *a, **k: (None, "")
+    )
+
+    ens = EnsembleModel.__new__(EnsembleModel)
+    ens.device = torch.device("cpu")
+    ens.weights_path = str(path)
+    ens.models = [types.SimpleNamespace(load_state_dict=lambda *a, **k: None)]
+    ens.optimizers = [
+        types.SimpleNamespace(param_groups=[{"lr": 1e-3, "weight_decay": 0.0}])
+    ]
+    ens.load_best_weights(str(path), data_full=[[0, 0, 0, 0, 0, 0]] * 30)
+
+    assert G.global_net_pct == 123.0
+    assert G.global_best_net_pct == 123.0
+    assert G.global_num_trades == 4
+    assert G.global_win_rate == 0.5
+    assert G.global_profit_factor == 1.2


### PR DESCRIPTION
## Summary
- sync global stats with the loaded best equity curve
- update yearly and monthly tables when loading best weights
- test that `load_best_weights` updates current metrics

## Testing
- `pre-commit run --all-files`
- `NO_HEAVY=1 pytest -q tests/test_best_weights_load.py`

------
https://chatgpt.com/codex/tasks/task_e_687817c7cf5483249271c840393a02a4