### PR TITLE
Improve not promoted logs

### DIFF
--- a/artibot/ensemble.py
+++ b/artibot/ensemble.py
@@ -949,6 +949,14 @@ class EnsembleModel(nn.Module):
                         },
                     )
             else:
+                if trades_now == 0:
+                    logging.info("NOT_PROMOTED: trades = 0")
+                else:
+                    logging.info(
+                        "NOT_PROMOTED: composite_reward=%.1f < %.1f",
+                        cur_reward,
+                        self.best_composite_reward,
+                    )
                 self.patience_counter += 1
                 # If net improvements are small => bigger patience
                 # If average improvement >=1 => shorter patience


### PR DESCRIPTION
## Summary
- log composite reward rejections
- log not promoted when 0 trades
- test zero-trade log update
- test composite reward not promoted message

## Testing
- `pre-commit run --all-files`
- `pytest tests/test_ignore_zero_trades.py tests/test_not_promoted_logging.py tests/test_new_best_logging.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68781b0b81f0832490b87122bc8f93c6