### PR TITLE
Update GUI metrics on every backtest

### DIFF
--- a/artibot/backtest.py
+++ b/artibot/backtest.py
@@ -696,9 +696,8 @@ if __name__ == "__main__":
         max_epochs=1,
     )
     result = robust_backtest(ens, data)
-    G.global_equity_curve = result["equity_curve"]
-    G.global_backtest_profit.append(result["net_pct"])
-    G.global_sharpe = result["sharpe"]
-    G.global_profit_factor = result["profit_factor"]
-    G.gui_event.set()
+    if result.get("trades", 0) == 0:
+        logging.info("IGNORED_EMPTY_BACKTEST: 0 trades in result")
+    else:
+        G.push_backtest_metrics(result)
     print(result)

--- a/artibot/ensemble.py
+++ b/artibot/ensemble.py
@@ -467,6 +467,11 @@ class EnsembleModel(nn.Module):
                     self, data_full
                 )  # no “features” arg inside sweep
 
+                if result.get("trades", 0) == 0:
+                    logging.info("IGNORED_EMPTY_BACKTEST: 0 trades in result")
+                else:
+                    G.push_backtest_metrics(result)
+
                 logging.info(
                     "SWEEP_CFG",
                     extra={
@@ -545,11 +550,7 @@ class EnsembleModel(nn.Module):
 
         # --- ❹  Push to globals & ping GUI ------------------------------------------
         if not ignore_result:
-            G.global_equity_curve = current_result["equity_curve"]
-            G.global_backtest_profit.append(current_result["net_pct"])
-            G.global_sharpe = current_result["sharpe"]
-            G.global_profit_factor = current_result["profit_factor"]
-            G.gui_event.set()
+            G.push_backtest_metrics(current_result)
         # ---------------- END merged block ----------------
 
         if data_full:

--- a/artibot/globals.py
+++ b/artibot/globals.py
@@ -475,3 +475,41 @@ def sync_globals(hp, ind_hp) -> None:
         global_short_frac = hp.short_frac
         gross_long_usd = global_long_frac * live_equity
         gross_short_usd = global_short_frac * live_equity
+
+
+def push_backtest_metrics(result: dict) -> None:
+    """Update global performance metrics from a backtest result."""
+    global global_equity_curve
+    global global_backtest_profit
+    global global_inactivity_penalty
+    global global_composite_reward
+    global global_days_without_trading
+    global global_trade_details
+    global global_days_in_profit
+    global global_sharpe
+    global global_max_drawdown
+    global global_net_pct
+    global global_num_trades
+    global global_win_rate
+    global global_profit_factor
+    global global_avg_trade_duration
+    global global_avg_win
+    global global_avg_loss
+    with state_lock:
+        global_equity_curve = result["equity_curve"]
+        global_backtest_profit.append(result["net_pct"])
+        global_inactivity_penalty = result["inactivity_penalty"]
+        global_composite_reward = result["composite_reward"]
+        global_days_without_trading = result["days_without_trading"]
+        global_trade_details = result["trade_details"]
+        global_days_in_profit = result["days_in_profit"]
+        global_sharpe = result["sharpe"]
+        global_max_drawdown = result["max_drawdown"]
+        global_net_pct = result["net_pct"]
+        global_num_trades = result["trades"]
+        global_win_rate = result["win_rate"]
+        global_profit_factor = result["profit_factor"]
+        global_avg_trade_duration = result["avg_trade_duration"]
+        global_avg_win = result.get("avg_win", 0.0)
+        global_avg_loss = result.get("avg_loss", 0.0)
+    gui_event.set()

--- a/artibot/training.py
+++ b/artibot/training.py
@@ -912,11 +912,7 @@ def objective(trial: optuna.trial.Trial) -> float:
     if metrics.get("trades", 0) == 0:
         logging.info("IGNORED_EMPTY_BACKTEST: 0 trades in result")
     else:
-        G.global_equity_curve = metrics["equity_curve"]
-        G.global_backtest_profit.append(metrics["net_pct"])
-        G.global_sharpe = metrics["sharpe"]
-        G.global_profit_factor = metrics["profit_factor"]
-        G.gui_event.set()
+        G.push_backtest_metrics(metrics)
     return -metrics.get("composite_reward", 0.0)
 
 
@@ -947,10 +943,6 @@ def walk_forward_backtest(data: list, train_window: int, test_horizon: int) -> l
         if metrics.get("trades", 0) == 0:
             logging.info("IGNORED_EMPTY_BACKTEST: 0 trades in result")
         else:
-            G.global_equity_curve = metrics["equity_curve"]
-            G.global_backtest_profit.append(metrics["net_pct"])
-            G.global_sharpe = metrics["sharpe"]
-            G.global_profit_factor = metrics["profit_factor"]
-            G.gui_event.set()
+            G.push_backtest_metrics(metrics)
         results.append(metrics)
     return results

--- a/artibot/validation.py
+++ b/artibot/validation.py
@@ -136,11 +136,7 @@ def walk_forward_analysis(csv_path: str, config: dict) -> list[dict]:
         if metrics.get("trades", 0) == 0:
             logging.info("IGNORED_EMPTY_BACKTEST: 0 trades in result")
         else:
-            G.global_equity_curve = metrics["equity_curve"]
-            G.global_backtest_profit.append(metrics["net_pct"])
-            G.global_sharpe = metrics["sharpe"]
-            G.global_profit_factor = metrics["profit_factor"]
-            G.gui_event.set()
+            G.push_backtest_metrics(metrics)
         results.append(metrics)
     return results
 

--- a/artibot/walk_forward_opt.py
+++ b/artibot/walk_forward_opt.py
@@ -66,11 +66,10 @@ class EnsembleEstimator(BaseEstimator):
             raise RuntimeError("Estimator not fitted")
         df = pd.concat([X.reset_index(drop=True), y.reset_index(drop=True)], axis=1)
         metrics = robust_backtest(self.model_, df.values.tolist())
-        G.global_equity_curve = metrics["equity_curve"]
-        G.global_backtest_profit.append(metrics["net_pct"])
-        G.global_sharpe = metrics["sharpe"]
-        G.global_profit_factor = metrics["profit_factor"]
-        G.gui_event.set()
+        if metrics.get("trades", 0) == 0:
+            logging.info("IGNORED_EMPTY_BACKTEST: 0 trades in result")
+        else:
+            G.push_backtest_metrics(metrics)
         return float(metrics.get("net_pct", 0.0))
 
 
@@ -102,11 +101,10 @@ def walk_forward_opt(data: pd.DataFrame) -> List[Dict[str, Any]]:
         )
 
         metrics = robust_backtest(best_est.model_, test_df.values.tolist())
-        G.global_equity_curve = metrics["equity_curve"]
-        G.global_backtest_profit.append(metrics["net_pct"])
-        G.global_sharpe = metrics["sharpe"]
-        G.global_profit_factor = metrics["profit_factor"]
-        G.gui_event.set()
+        if metrics.get("trades", 0) == 0:
+            logging.info("IGNORED_EMPTY_BACKTEST: 0 trades in result")
+        else:
+            G.push_backtest_metrics(metrics)
         logging.info(
             "Window %d-%d  params=%s  net_pct=%.2f",
             start,


### PR DESCRIPTION
## Summary
- expose `push_backtest_metrics` helper in globals
- update sweep logic in `EnsembleModel` to push metrics
- refresh metrics in training, walk-forward routines and CLI backtest

## Testing
- `pre-commit run --all-files`
- `NO_HEAVY=1 pytest -q` *(fails: 69 failed, 68 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6878284f22b883248e538d6a4b78e422