### PR TITLE
Improve DEFCON phase logs

### DIFF
--- a/artibot/ensemble.py
+++ b/artibot/ensemble.py
@@ -535,6 +535,8 @@ class EnsembleModel(nn.Module):
             G.update_trade_params(best_cfg["sl"], best_cfg["tp"])
 
         # Run a back-test with the best parameters found (or current settings)
+        logging.info(">>> ENTERING DEFCON 3: Full Backtest")
+        logging.info(">>> Using current best hyperparams")
         current_result = best_result or robust_backtest(
             self, data_full, indicators=features
         )
@@ -641,6 +643,9 @@ class EnsembleModel(nn.Module):
                     shutil.copy(self.weights_path, live_path)
                     G.set_live_weights_updated(True)
                     logging.info("PROMOTED_TO_LIVE_MODEL hash=%s", md5)
+                    logging.info(
+                        "PROMOTION: Model meets Nuclear Key criteria, ready to trade."
+                    )
                 except Exception as exc:
                     logging.error("Live weight copy failed: %s", exc)
             else:

--- a/tests/test_defcon_logging.py
+++ b/tests/test_defcon_logging.py
@@ -1,0 +1,31 @@
+import logging
+import types
+
+import artibot.training as training
+
+
+def test_defcon5_logging(monkeypatch, caplog):
+    def dummy_objective(trial):
+        return 0.0
+
+    class DummyStudy:
+        def __init__(self):
+            self.trials = []
+            self.params = {"lr": 0.001, "entropy_beta": 0.001}
+
+        def optimize(self, func, n_trials=1, timeout=None):
+            trial = types.SimpleNamespace(params=self.params)
+            func(trial)
+            self.trials.append(trial)
+
+        @property
+        def best_params(self):
+            return self.params
+
+    monkeypatch.setattr(training, "objective", dummy_objective)
+    monkeypatch.setattr(training.optuna, "create_study", lambda direction: DummyStudy())
+
+    caplog.set_level(logging.INFO)
+    training.run_hpo(n_trials=1)
+
+    assert any("ENTERING DEFCON 5" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- add detailed DEFCON progress messages for hyperparameter search and walk‑forward
- log start of the full backtest with DEFCON 3 message
- emit promotion notice when nuclear key checks pass
- test DEFCON 5 logging

## Testing
- `pre-commit run --files artibot/training.py artibot/ensemble.py tests/test_defcon_logging.py`
- `NO_HEAVY=1 pytest tests/test_defcon_logging.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68782858df84832487bd58f432ed4c7f