### PR TITLE
Display Defcon status in GUI

### DIFF
--- a/artibot/ensemble.py
+++ b/artibot/ensemble.py
@@ -541,6 +541,7 @@ class EnsembleModel(nn.Module):
 
         # Run a back-test with the best parameters found (or current settings)
         logging.info(">>> ENTERING DEFCON 3: Full Backtest")
+        G.set_defcon("DEFCON 3 \u2013 Full Dataset Backtest")
         logging.info(">>> Using current best hyperparams")
         current_result = best_result or robust_backtest(
             self, data_full, indicators=features
@@ -647,6 +648,7 @@ class EnsembleModel(nn.Module):
                     logging.info(
                         "PROMOTION: Model meets Nuclear Key criteria, ready to trade."
                     )
+                    G.set_defcon("DEFCON 2 \u2013 Ready to Trade (NK Safe)")
                 except Exception as exc:
                     logging.error("Live weight copy failed: %s", exc)
             else:

--- a/artibot/globals.py
+++ b/artibot/globals.py
@@ -201,6 +201,7 @@ nuke_armed = False  # GUI override
 global_primary_status = "Initializing..."  # displayed in GUI
 global_secondary_status = ""
 global_progress_pct = 0.0
+current_defcon: str = ""
 
 # Flag toggled by GUI when user enables live trading
 live_trading_enabled = False  # set via GUI toggle
@@ -253,6 +254,14 @@ def set_status(msg: str, secondary: str | None = None) -> None:
         global_primary_status = msg
         if secondary is not None:
             global_secondary_status = secondary
+
+
+def set_defcon(label: str) -> None:
+    """Update :data:`current_defcon` and notify the GUI."""
+    global current_defcon
+    with state_lock:
+        current_defcon = label
+    gui_event.set()
 
 
 def get_status() -> str:

--- a/artibot/gui_v2.py
+++ b/artibot/gui_v2.py
@@ -932,8 +932,12 @@ class TradingGUI:
 
         primary, secondary = G.get_status_full()
         nk_state = "ARMED" if G.nuke_armed else "SAFE"
-        self.phase_var.set(f"{primary}\n{secondary}")
-        self.status_var.set(f"{primary} | NK {nk_state} \n{secondary}")
+        if G.current_defcon:
+            self.phase_var.set(G.current_defcon)
+            self.status_var.set(f"NK {nk_state}\n{secondary}")
+        else:
+            self.phase_var.set(f"{primary}\n{secondary}")
+            self.status_var.set(f"{primary} | NK {nk_state} \n{secondary}")
         self.progress["value"] = G.global_progress_pct
 
         _ = G.live_equity - G.start_equity
@@ -1041,6 +1045,7 @@ class TradingGUI:
         """Activate live trading and disable the NK button."""
         G.live_trading_enabled = True
         logging.info("LIVE_TRADING_ENABLED")
+        G.set_defcon("DEFCON 1 \u2013 LIVE TRADE ACTIVE")
         G.set_status("Live trading enabled", "Use caution")
         self.nuclear_button.config(state=tk.DISABLED)
 

--- a/artibot/training.py
+++ b/artibot/training.py
@@ -918,8 +918,8 @@ def objective(trial: optuna.trial.Trial) -> float:
 
 def run_hpo(n_trials: int = 50) -> dict:
     """Run Bayesian hyper-parameter search with Optuna."""
-
     logging.info(">>> ENTERING DEFCON 5: Hyperparameter Search")
+    G.set_defcon("DEFCON 5 \u2013 Hyperparameter Search")
     logging.info(">>> Starting Sweep: 0 of %d", n_trials)
     G.set_status("DEFCON 5: Hyperparameter Search", "starting")
     study = optuna.create_study(direction="minimize")
@@ -939,8 +939,8 @@ def run_hpo(n_trials: int = 50) -> dict:
 
 def walk_forward_backtest(data: list, train_window: int, test_horizon: int) -> list:
     """Perform walk-forward validation across ``data``."""
-
     logging.info(">>> ENTERING DEFCON 4: Walk Forward Evaluation")
+    G.set_defcon("DEFCON 4 \u2013 Walk Forward Evaluation")
     results: list = []
     n_folds = max(1, (len(data) - train_window - test_horizon) // test_horizon + 1)
     fold_idx = 1

--- a/run_artibot.py
+++ b/run_artibot.py
@@ -308,7 +308,7 @@ def main() -> None:
             train_mode=False,
         )
         n_features = temp_ds[0][0].shape[1]
-
+        G.set_defcon("DEFCON 5 \u2013 Hyperparameter Search")
         if no_tune:
             G.set_status("DEFCON 5: Hyperparameter Search", "skipped")
             best = {}

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -23,6 +23,8 @@ def load_metrics():
     globals_stub = types.ModuleType("artibot.globals")
     globals_stub.pd = pd
     globals_stub.np = np
+    globals_stub.set_defcon = lambda *a, **k: None
+    globals_stub.current_defcon = ""
     sys.modules["artibot.globals"] = globals_stub
 
     spec = importlib.util.spec_from_file_location("artibot.metrics", METRICS_PATH)

--- a/tests/test_rl.py
+++ b/tests/test_rl.py
@@ -56,6 +56,12 @@ def load_rl_module():
     stub.timeline_index = 0
     stub.timeline_ind_on = np.zeros((stub.timeline_depth, 6), dtype=np.uint8)
     stub.timeline_trades = np.zeros(stub.timeline_depth, dtype=np.uint8)
+    stub.current_defcon = ""
+
+    def set_defcon(label: str) -> None:
+        stub.current_defcon = label
+
+    stub.set_defcon = set_defcon
     sys.modules["artibot.globals"] = stub
 
     base = Path(__file__).resolve().parent.parent / "artibot"

--- a/tests/test_status_dialog.py
+++ b/tests/test_status_dialog.py
@@ -11,6 +11,13 @@ def test_set_status_and_full():
     assert G.get_status_full() == ("Working", "epoch 3")
 
 
+def test_set_defcon_sets_event():
+    G.gui_event.clear()
+    G.set_defcon("DEFCON 5 – Hyperparameter Search")
+    assert G.current_defcon.startswith("DEFCON 5")
+    assert G.gui_event.is_set()
+
+
 def test_weight_dialog_default(monkeypatch):
     tk_stub = types.SimpleNamespace(
         messagebox=types.SimpleNamespace(askyesno=lambda *a, **k: True),


### PR DESCRIPTION
## Summary
- show current DEFCON phase in the GUI header via `current_defcon`
- propagate DEFCON level through training phases and live trading
- update GUI refresh logic for the new header
- add `set_defcon` helper to globals
- adjust tests for new helper

## Testing
- `pre-commit run --all-files`
- `pytest -q --no-heavy` *(fails: 69 failed, 70 passed)*


------
https://chatgpt.com/codex/tasks/task_e_68782d010aa88324ad4309367742efb4