### PR TITLE
Fix composite reward comparison

### DIFF
--- a/artibot/ensemble.py
+++ b/artibot/ensemble.py
@@ -599,11 +599,9 @@ class EnsembleModel(nn.Module):
             G.global_monthly_stats_table = monthly_table
 
         # update live weights when the composite reward improves
-        best = (
-            G.global_best_composite_reward
-            if G.global_best_composite_reward is not None
-            else float("-inf")
-        )
+        # ``global_best_composite_reward`` defaults to ``-inf`` so a separate
+        # ``None`` check is unnecessary
+        best = G.global_best_composite_reward
         if (
             update_globals
             and not ignore_result


### PR DESCRIPTION
## Summary
- simplify composite score initialization logic

## Testing
- `pre-commit run --files artibot/ensemble.py`
- `pytest -q` *(fails: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_687839ed81d4832488f876c8bbea7974