### PR TITLE
Fix checkpoint best reward persistence

### DIFF
--- a/artibot/training.py
+++ b/artibot/training.py
@@ -872,6 +872,7 @@ def save_checkpoint():
         "gpt_memory_bigmanblastoise": G.gpt_memory_bigmanblastoise,
         "gpt_memory_moneymaker": G.gpt_memory_moneymaker,
         "global_attention_weights_history": G.global_attention_weights_history,
+        "best_reward": G.global_best_composite_reward,
     }
     with open("checkpoint.json", "w") as f:
         json.dump(checkpoint, f, indent=2)

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,6 +1,22 @@
+import json
+import os
+
 from artibot import globals as G, state
 
 
 def test_best_reward_never_none_after_state_load(dummy_checkpoint):
     state.load(dummy_checkpoint)
     assert G.global_best_composite_reward is not None
+
+
+def test_checkpoint_roundtrip_best_reward(tmp_path):
+    G.global_best_composite_reward = 7.5
+    os.chdir(tmp_path)
+    from artibot.training import save_checkpoint
+
+    save_checkpoint()
+    data = json.load(open("checkpoint.json"))
+    assert data["best_reward"] == 7.5
+    G.global_best_composite_reward = float("-inf")
+    state.load("checkpoint.json")
+    assert G.global_best_composite_reward == 7.5


### PR DESCRIPTION
## Summary
- save the best composite reward in `save_checkpoint`
- test round-tripping of best reward via checkpoints

## Testing
- `pre-commit run --files artibot/training.py tests/test_state.py`
- `pytest -q tests/test_state.py::test_checkpoint_roundtrip_best_reward --no-heavy`

------
https://chatgpt.com/codex/tasks/task_e_687839ff9594832494fac1d4fd0b35e4