### PR TITLE
Disable risk filter in ensemble training

### DIFF
--- a/artibot/ensemble.py
+++ b/artibot/ensemble.py
@@ -955,38 +955,39 @@ class EnsembleModel(nn.Module):
                 G.set_status("Warning: attention entropy < 0.5", "")
 
             if cur_reward > self.best_composite_reward and trades_now > 0:
-                if reject_if_risky(
-                    cur_reward,
-                    G.global_max_drawdown,
-                    attn_entropy,
-                ):
-                    self.rejection_count_this_epoch += 1
-                    logging.info(
-                        "REJECTED by risk filter",
-                        extra={
-                            "epoch": self.train_steps,
-                            "sharpe": G.global_sharpe,
-                            "max_dd": G.global_max_drawdown,
-                            "attn_entropy": attn_entropy,
-                            "lr": self.optimizers[0].param_groups[0]["lr"],
-                        },
-                    )
-                    G.set_status("Risk", "Epoch rejected")
-                else:
-                    self.best_composite_reward = cur_reward
-                    self.patience_counter = 0
-                    self.best_state_dicts = [m.state_dict() for m in self.models]
-                    self.save_best_weights()
-                    logging.info(
-                        "NEW_BEST_CANDIDATE",
-                        extra={
-                            "epoch": self.train_steps,
-                            "sharpe": G.global_sharpe,
-                            "max_dd": G.global_max_drawdown,
-                            "attn_entropy": attn_entropy,
-                            "lr": self.optimizers[0].param_groups[0]["lr"],
-                        },
-                    )
+                # Disable risk-based rejection of epoch improvements
+                # if reject_if_risky(
+                #     cur_reward,
+                #     G.global_max_drawdown,
+                #     attn_entropy,
+                # ):
+                #     self.rejection_count_this_epoch += 1
+                #     logging.info(
+                #         "REJECTED by risk filter",
+                #         extra={
+                #             "epoch": self.train_steps,
+                #             "sharpe": G.global_sharpe,
+                #             "max_dd": G.global_max_drawdown,
+                #             "attn_entropy": attn_entropy,
+                #             "lr": self.optimizers[0].param_groups[0]["lr"],
+                #         },
+                #     )
+                #     G.set_status("Risk", "Epoch rejected")
+                # else:
+                self.best_composite_reward = cur_reward
+                self.patience_counter = 0
+                self.best_state_dicts = [m.state_dict() for m in self.models]
+                self.save_best_weights()
+                logging.info(
+                    "NEW_BEST_CANDIDATE",
+                    extra={
+                        "epoch": self.train_steps,
+                        "sharpe": G.global_sharpe,
+                        "max_dd": G.global_max_drawdown,
+                        "attn_entropy": attn_entropy,
+                        "lr": self.optimizers[0].param_groups[0]["lr"],
+                    },
+                )
             else:
                 if trades_now == 0:
                     logging.info("NOT_PROMOTED: trades = 0")
@@ -1104,11 +1105,8 @@ class EnsembleModel(nn.Module):
             if self.train_steps > 0:
                 update_best(
                     self.train_steps,
-
                     current_result["composite_reward"],
-
                     raw_reward,
-
                     current_result["net_pct"],
                     self.weights_path,
                 )

--- a/artibot/globals.py
+++ b/artibot/globals.py
@@ -151,7 +151,7 @@ use_sharpe_term = True  # include Sharpe ratio
 use_drawdown_term = True  # include drawdown term
 use_trade_term = True  # include trade count
 use_profit_days_term = True  # include days in profit
-risk_filter_enabled = True  # training loss gating
+risk_filter_enabled = False  # training loss gating disabled by default
 
 ###############################################################################
 # GPT Memories (unchanged)

--- a/tests/test_risk_gate_integration.py
+++ b/tests/test_risk_gate_integration.py
@@ -1,5 +1,8 @@
+import artibot.globals as G
 from artibot.ensemble import reject_if_risky
 
 
-def test_gate_triggered():
-    assert reject_if_risky(sharpe=0.8, max_dd=-0.2, entropy=0.5) is True
+def test_gate_triggered(monkeypatch):
+    monkeypatch.setattr(G, "risk_filter_enabled", True)
+    monkeypatch.setattr(G, "global_num_trades", 2000)
+    assert reject_if_risky(reward=0.8, max_dd=-0.2, entropy=0.5) is True


### PR DESCRIPTION
## Summary
- bypass the risk gate when updating best models
- default the risk filter to `False`
- adjust risk gate integration test

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: ImportError: cannot import name ...)*

------
https://chatgpt.com/codex/tasks/task_e_68794f75c62c8324b6840eccd5de5875