### PR TITLE
Add best weight logging

### DIFF
--- a/artibot/ensemble.py
+++ b/artibot/ensemble.py
@@ -627,6 +627,12 @@ class EnsembleModel(nn.Module):
             G.global_best_monthly_stats_table = monthly_table
             self.best_state_dicts = [m.state_dict() for m in self.models]
             self.save_best_weights(self.weights_path)
+            logging.info(
+                "SAVED_BEST_WEIGHTS epoch=%d reward=%.2f path=%s",
+                self.train_steps,
+                current_result["composite_reward"],
+                self.weights_path,
+            )
             md5 = ""
             try:
                 with open(self.weights_path, "rb") as f:
@@ -921,6 +927,12 @@ class EnsembleModel(nn.Module):
                 G.global_best_monthly_stats_table = monthly_table
                 self.best_state_dicts = [m.state_dict() for m in self.models]
                 self.save_best_weights(self.weights_path)
+                logging.info(
+                    "SAVED_BEST_WEIGHTS epoch=%d reward=%.2f path=%s",
+                    self.train_steps,
+                    current_result["composite_reward"],
+                    self.weights_path,
+                )
 
             # Apply penalties for low trade count or negative net after tracking
             # the raw reward.  These penalties influence patience and rejection
@@ -977,6 +989,12 @@ class EnsembleModel(nn.Module):
                     self.patience_counter = 0
                     self.best_state_dicts = [m.state_dict() for m in self.models]
                     self.save_best_weights()
+                    logging.info(
+                        "SAVED_BEST_WEIGHTS epoch=%d reward=%.2f path=%s",
+                        self.train_steps,
+                        current_result["composite_reward"],
+                        self.weights_path,
+                    )
                     logging.info(
                         "NEW_BEST_CANDIDATE",
                         extra={
@@ -1101,14 +1119,17 @@ class EnsembleModel(nn.Module):
             G.global_best_monthly_stats_table = best_monthly
             self.best_state_dicts = [m.state_dict() for m in self.models]
             self.save_best_weights(self.weights_path)
+            logging.info(
+                "SAVED_BEST_WEIGHTS epoch=%d reward=%.2f path=%s",
+                self.train_steps,
+                current_result["composite_reward"],
+                self.weights_path,
+            )
             if self.train_steps > 0:
                 update_best(
                     self.train_steps,
-
                     current_result["composite_reward"],
-
                     raw_reward,
-
                     current_result["net_pct"],
                     self.weights_path,
                 )

--- a/tests/test_save_best_weights_logging.py
+++ b/tests/test_save_best_weights_logging.py
@@ -1,0 +1,90 @@
+import logging
+import sys
+import types
+from types import SimpleNamespace
+from importlib.machinery import ModuleSpec
+
+# ruff: noqa: E402
+
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+for name in ["openai", "ccxt", "tkinter", "tkinter.ttk"]:
+    mod = types.ModuleType(name)
+    mod.__spec__ = ModuleSpec(name, loader=None)
+    sys.modules.setdefault(name, mod)
+
+matplotlib = types.ModuleType("matplotlib")
+matplotlib.use = lambda *a, **k: None
+matplotlib.__spec__ = ModuleSpec("matplotlib", loader=None)
+sys.modules.setdefault("matplotlib", matplotlib)
+pyplot = types.ModuleType("pyplot")
+pyplot.__spec__ = ModuleSpec("pyplot", loader=None)
+sys.modules.setdefault("matplotlib.pyplot", pyplot)
+
+import artibot.globals as G
+from artibot.ensemble import EnsembleModel
+from artibot.utils import get_device
+
+
+def test_save_best_weights_logging(monkeypatch, caplog):
+    device = get_device()
+
+    def dummy_backtest(ensemble, data_full, indicators=None):
+        return {
+            "equity_curve": [],
+            "effective_net_pct": 1.0,
+            "inactivity_penalty": 0.0,
+            "composite_reward": 10.0,
+            "days_without_trading": 0,
+            "trade_details": [0],
+            "days_in_profit": 0.0,
+            "sharpe": 1.0,
+            "max_drawdown": -0.1,
+            "net_pct": 1.0,
+            "trades": 5,
+            "win_rate": 0.5,
+            "profit_factor": 1.0,
+            "avg_trade_duration": 0.0,
+            "avg_win": 0.0,
+            "avg_loss": 0.0,
+        }
+
+    def dummy_stats(ec, trades, initial_balance=100.0):
+        return None, ""
+
+    monkeypatch.setattr("artibot.ensemble.robust_backtest", dummy_backtest)
+    monkeypatch.setattr("artibot.ensemble.compute_yearly_stats", dummy_stats)
+    import artibot.constants as const
+    monkeypatch.setattr(const, "FEATURE_DIMENSION", 8)
+    import artibot.model as model
+    monkeypatch.setattr(model, "FEATURE_DIMENSION", 8)
+
+    ens = EnsembleModel(device=device, n_models=1, n_features=8)
+
+    class DummyModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.fc = torch.nn.Linear(8, 3)
+
+        def forward(self, x):
+            batch = x.size(0)
+            logits = x.mean(dim=1) @ self.fc.weight.T
+            return logits, SimpleNamespace(), torch.zeros(batch)
+
+    ens.models = [DummyModel().to(device)]
+    ens.optimizers = [torch.optim.AdamW(ens.models[0].parameters(), lr=1e-3)]
+
+    ds = TensorDataset(torch.zeros(1, 24, 8), torch.zeros(1, dtype=torch.long))
+    dl = DataLoader(ds, batch_size=1, pin_memory=True)
+
+    G.global_attention_entropy_history = [1.2]
+    G.global_sharpe = 1.2
+    G.global_max_drawdown = -0.1
+
+    ens.train_steps = 1
+
+    caplog.set_level(logging.INFO)
+    ens.train_one_epoch(dl, dl, [])
+
+    assert any("SAVED_BEST_WEIGHTS" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- log weight persistence whenever composite reward improves
- test that saved weight message appears

## Testing
- `pre-commit run --all-files`
- `pytest -q --no-heavy` *(fails: ModuleNotFoundError: No module named 'tensorboard')*

------
https://chatgpt.com/codex/tasks/task_e_68794f98331c8324a04925812359045a