### PR TITLE
Use hyperparams in smoke test

### DIFF
--- a/artibot/ensemble.py
+++ b/artibot/ensemble.py
@@ -241,6 +241,8 @@ class EnsembleModel(nn.Module):
             rsi_period=14, sma_period=10, macd_fast=12, macd_slow=26, macd_signal=9
         )
         self.hp = HyperParams(indicator_hp=self.indicator_hparams)
+        if lr is not None:
+            self.hp.learning_rate = lr
 
         # Determine the feature dimension either from the caller or fall back
         # to the package constant.  This allows the ensemble to align its input
@@ -260,7 +262,7 @@ class EnsembleModel(nn.Module):
         print("[DEBUG] Model moved to device")
         from . import hyperparams as _hp
 
-        lr = max(lr, _hp.LR_MIN)
+        lr = max(self.hp.learning_rate, _hp.LR_MIN)
         self.optimizers = [
             optim.AdamW(
                 m.parameters(),

--- a/artibot/globals.py
+++ b/artibot/globals.py
@@ -20,7 +20,10 @@ import matplotlib
 import numpy as np
 import torch
 
-matplotlib.use("TkAgg")
+if os.environ.get("HEADLESS") or os.environ.get("MPLBACKEND") == "Agg":
+    matplotlib.use("Agg")
+else:
+    matplotlib.use("TkAgg")
 
 # Reduce default logging to warnings only
 import logging

--- a/tests/test_hyperparams.py
+++ b/tests/test_hyperparams.py
@@ -6,5 +6,5 @@ from artibot import hyperparams
 def test_hyperparams_defaults():
     importlib.reload(hyperparams)
     hp = hyperparams.HyperParams()
-    assert hp.learning_rate > 0
+    assert 1e-4 < hp.learning_rate < 1e-3
     assert isinstance(hp.use_sma, bool)


### PR DESCRIPTION
## Summary
- use HyperParams defaults in the smoke test
- allow headless matplotlib for tests
- handle backtest failures gracefully
- add `learning_rate` CLI flag and HyperParams check

## Testing
- `pre-commit run --all-files`
- `pytest tests/test_hyperparams.py -q`


------
https://chatgpt.com/codex/tasks/task_e_687b034954dc83249d15ca0d5fd40551