### PR TITLE
Add automatic LR finder

### DIFF
--- a/artibot/hyperparams.py
+++ b/artibot/hyperparams.py
@@ -54,6 +54,14 @@ class HyperParams:
     use_momentum: bool = bool(_CONFIG.get("USE_MOMENTUM", False))
     use_bbw: bool = bool(_CONFIG.get("USE_BBW", False))
 
+    auto_lr: bool = bool(_CONFIG.get("AUTO_LR", True))
+    lr_min: float = float(_CONFIG.get("LR_MIN", 1e-7))
+    lr_max: float = float(_CONFIG.get("LR_MAX", 1e-1))
+    lr_probe_steps: int = int(_CONFIG.get("LR_PROBE_STEPS", 100))
+    lr_probe_samples: int = int(_CONFIG.get("LR_PROBE_SAMPLES", 2048))
+    epochs: int = int(_CONFIG.get("EPOCHS", 30))
+    batch_size: int = int(_CONFIG.get("BATCH_SIZE", 512))
+
     def __post_init__(self) -> None:
         if self.indicator_hp is None:
             self.indicator_hp = IndicatorHyperparams()

--- a/artibot/lr_finder.py
+++ b/artibot/lr_finder.py
@@ -1,0 +1,78 @@
+"""Learning rate range test utilities."""
+
+from __future__ import annotations
+
+from typing import List
+
+import torch
+from torch.utils.data import DataLoader
+
+
+def find_optimal_lr(
+    model: torch.nn.Module,
+    loss_fn: torch.nn.Module,
+    dataset: torch.utils.data.Dataset,
+    hp,
+    *,
+    min_lr: float = 1e-7,
+    max_lr: float = 1e-1,
+    num_iter: int = 100,
+    beta: float = 0.98,
+    device: torch.device | str = "cpu",
+) -> tuple[float, list[tuple[float, float]]]:
+    """Run the Leslie Smith LR-range test and return a suggested LR."""
+
+    device = torch.device(device)
+    bs = getattr(hp, "batch_size", 64)
+    loader = DataLoader(dataset, batch_size=bs, shuffle=True, drop_last=True)
+
+    lr_mult = (max_lr / min_lr) ** (1 / num_iter)
+    lr = min_lr
+    optimizer = torch.optim.SGD(model.parameters(), lr=lr)
+
+    lrs: List[float] = []
+    losses: List[float] = []
+    avg_loss = 0.0
+    best_loss = float("inf")
+
+    data_iter = iter(loader)
+    model.train()
+    for step in range(num_iter):
+        try:
+            x, y = next(data_iter)
+        except StopIteration:
+            data_iter = iter(loader)
+            x, y = next(data_iter)
+
+        x = x.to(device)
+        y = y.to(device)
+
+        optimizer.zero_grad()
+        out = model(x)
+        if isinstance(out, tuple):
+            out = out[0]
+        loss = loss_fn(out, y)
+        loss_value = float(loss.item())
+
+        avg_loss = beta * avg_loss + (1 - beta) * loss_value
+        smoothed = avg_loss / (1 - beta ** (step + 1))
+
+        lrs.append(lr)
+        losses.append(smoothed)
+
+        if smoothed < best_loss or step == 0:
+            best_loss = smoothed
+        if smoothed > 4 * best_loss:
+            break
+
+        loss.backward()
+        optimizer.step()
+
+        lr *= lr_mult
+        for pg in optimizer.param_groups:
+            pg["lr"] = lr
+
+    if not losses:
+        return min_lr, []
+    idx = int(min(range(len(losses)), key=losses.__getitem__))
+    return lrs[idx], list(zip(lrs, losses))

--- a/tests/test_lr_finder.py
+++ b/tests/test_lr_finder.py
@@ -1,0 +1,26 @@
+import torch
+from torch.utils.data import TensorDataset
+
+from artibot.lr_finder import find_optimal_lr
+from artibot.hyperparams import HyperParams
+
+
+def test_lr_finder_returns_reasonable_lr():
+    x = torch.randn(256, 10)
+    y = torch.randn(256, 1)
+    ds = TensorDataset(x, y)
+    model = torch.nn.Sequential(torch.nn.Linear(10, 1))
+    hp = HyperParams()
+    hp.batch_size = 16
+    lr, curve = find_optimal_lr(
+        model,
+        torch.nn.MSELoss(),
+        ds,
+        hp,
+        min_lr=1e-5,
+        max_lr=1e-2,
+        num_iter=50,
+        device="cpu",
+    )
+    assert curve
+    assert 1e-5 < lr < 1e-2


### PR DESCRIPTION
## Summary
- add Leslie Smith LR-range test util
- expose LR finder hyperparameters
- integrate LR probing into training loop
- construct OneCycle schedule around probed LR
- test learning-rate finder

## Testing
- `pre-commit run --files artibot/hyperparams.py artibot/lr_finder.py artibot/training.py tests/test_lr_finder.py`
- `pytest -q tests/test_lr_finder.py`

------
https://chatgpt.com/codex/tasks/task_e_687bd763b5348324a2b0f3df810c328c