### PR TITLE
Allow indicator HPO

### DIFF
--- a/artibot/backtest.py
+++ b/artibot/backtest.py
@@ -659,9 +659,7 @@ if __name__ == "__main__":
     ds_tmp = HourlyDataset(
         data,
         seq_len=24,
-        indicator_hparams=IndicatorHyperparams(
-            rsi_period=14, sma_period=10, macd_fast=12, macd_slow=26, macd_signal=9
-        ),
+        indicator_hparams=IndicatorHyperparams(),
         atr_threshold_k=1.5,
         train_mode=False,
     )

--- a/artibot/bot_app.py
+++ b/artibot/bot_app.py
@@ -159,9 +159,7 @@ def run_bot(max_epochs: int | None = None, *, overfit_toy: bool = False) -> None
         msg += f" ({torch.cuda.get_device_name(0)})"
     logging.info(msg)
 
-    indicator_hp = IndicatorHyperparams(
-        rsi_period=14, sma_period=10, macd_fast=12, macd_slow=26, macd_signal=9
-    )
+    indicator_hp = IndicatorHyperparams()
     ds_tmp = HourlyDataset(
         data,
         seq_len=24,

--- a/artibot/ensemble.py
+++ b/artibot/ensemble.py
@@ -237,9 +237,8 @@ class EnsembleModel(nn.Module):
         device = torch.device(device) if device is not None else get_device()
         self.device = device
         self.weights_path = weights_path
-        self.indicator_hparams = IndicatorHyperparams(
-            rsi_period=14, sma_period=10, macd_fast=12, macd_slow=26, macd_signal=9
-        )
+        # use config defaults for all indicator settings
+        self.indicator_hparams = IndicatorHyperparams()
         self.hp = HyperParams(indicator_hp=self.indicator_hparams)
         if lr is not None:
             self.hp.learning_rate = lr

--- a/artibot/validation.py
+++ b/artibot/validation.py
@@ -79,9 +79,7 @@ def walk_forward_analysis(csv_path: str, config: dict) -> list[dict]:
     data = sanitize_features(raw_data)
     device = get_device()
 
-    indicator_hp = IndicatorHyperparams(
-        rsi_period=14, sma_period=10, macd_fast=12, macd_slow=26, macd_signal=9
-    )
+    indicator_hp = IndicatorHyperparams()
     ds_tmp = HourlyDataset(
         data,
         seq_len=24,

--- a/scripts/smoke.py
+++ b/scripts/smoke.py
@@ -33,9 +33,7 @@ def main() -> None:
     set_threads(int(os.environ.get("OMP_NUM_THREADS", os.cpu_count() or 1)))
     ensure_dependencies()
     data = load_csv_hourly("Gemini_BTCUSD_1h.csv")[:500]
-    indicator_hp = IndicatorHyperparams(
-        rsi_period=14, sma_period=10, macd_fast=12, macd_slow=26, macd_signal=9
-    )
+    indicator_hp = IndicatorHyperparams()
     ds_tmp = HourlyDataset(
         data,
         seq_len=24,


### PR DESCRIPTION
## Summary
- broaden hyperparameter optimisation to toggle every indicator
- load indicators from config throughout the codebase
- respect HPO indicator settings in run_artibot

## Testing
- `pre-commit run --all-files`
- `pytest -q --no-heavy` *(fails: AttributeError module 'pandas' has no attribute 'Timestamp', many others)*

------
https://chatgpt.com/codex/tasks/task_e_687e59d121d08324b432b340dd0c70d3