### PR TITLE
Fix gradient clipping order and add RL delay config

### DIFF
--- a/tests/test_ensemble_grad_accum.py
+++ b/tests/test_ensemble_grad_accum.py
@@ -1,0 +1,69 @@
+import types
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+from artibot.ensemble import EnsembleModel
+import artibot.constants as const
+import artibot.model as model
+
+
+def test_optimizer_steps_with_grad_accum(monkeypatch):
+    device = torch.device("cpu")
+
+    def dummy_backtest(*a, **k):
+        return {
+            "equity_curve": [(0, 100.0)],
+            "effective_net_pct": 0.0,
+            "inactivity_penalty": 0.0,
+            "composite_reward": 0.1,
+            "days_without_trading": 0,
+            "trade_details": [],
+            "days_in_profit": 0.0,
+            "sharpe": 0.1,
+            "max_drawdown": -0.1,
+            "net_pct": 0.0,
+            "trades": 1,
+            "win_rate": 1.0,
+            "profit_factor": 1.0,
+            "avg_trade_duration": 0.0,
+            "avg_win": 0.0,
+            "avg_loss": 0.0,
+        }
+
+    monkeypatch.setattr("artibot.ensemble.robust_backtest", dummy_backtest)
+    monkeypatch.setattr("artibot.ensemble.compute_yearly_stats", lambda *a, **k: (None, ""))
+    monkeypatch.setattr("artibot.ensemble.compute_monthly_stats", lambda *a, **k: (None, ""))
+
+    monkeypatch.setattr(const, "FEATURE_DIMENSION", 8)
+    monkeypatch.setattr(model, "FEATURE_DIMENSION", 8)
+
+    ens = EnsembleModel(device=device, n_models=1, n_features=8, grad_accum_steps=2, delayed_reward_epochs=0)
+
+    class DummyModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.w = torch.nn.Parameter(torch.zeros(8, 3))
+
+        def forward(self, x):
+            batch = x.size(0)
+            logits = x.mean(dim=1) @ self.w
+            return logits, types.SimpleNamespace(), torch.zeros(batch)
+
+    ens.models = [DummyModel().to(device)]
+    opt = torch.optim.SGD(ens.models[0].parameters(), lr=0.1)
+    ens.optimizers = [opt]
+
+    ds = TensorDataset(torch.zeros(3, 24, 8), torch.zeros(3, dtype=torch.long))
+    dl = DataLoader(ds, batch_size=1)
+
+    calls = []
+    orig_step = opt.step
+
+    def counting_step(*a, **k):
+        calls.append(True)
+        return orig_step(*a, **k)
+
+    opt.step = counting_step
+
+    ens.train_one_epoch(dl, None, [], update_globals=False)
+
+    assert len(calls) == 2

--- a/tests/test_training_loop_simple.py
+++ b/tests/test_training_loop_simple.py
@@ -1,0 +1,24 @@
+import torch
+from training_loop import train_step
+
+
+class DummyModel(torch.nn.Linear):
+    def forward(self, x):
+        logits = super().forward(x)
+        return logits, None, None
+
+
+def test_train_step_improves_loss():
+    torch.manual_seed(0)
+    model = DummyModel(2, 3)
+    opt = torch.optim.SGD(model.parameters(), lr=0.1)
+    batch_x = torch.randn(32, 2)
+    weights = torch.tensor([[1.0, 1.0], [-1.0, -1.0], [1.0, -1.0]])
+    with torch.no_grad():
+        labels = (batch_x @ weights.T).argmax(dim=1)
+    batch = (batch_x, labels)
+    init = torch.nn.functional.cross_entropy(model(batch_x)[0], labels)
+    loss = init.item()
+    for _ in range(50):
+        loss = train_step(model, opt, None, batch)
+    assert loss < init.item()

--- a/training_loop.py
+++ b/training_loop.py
@@ -12,10 +12,11 @@ def train_step(model, optimizer, scheduler, batch):
     model.train()
     x, y = batch
     optimizer.zero_grad()
-    out = model(x)
-    loss = torch.nn.functional.cross_entropy(out, y)
-    torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+    logits = model(x)[0]
+    y = y.view(-1).long()
+    loss = torch.nn.functional.cross_entropy(logits, y)
     loss.backward()
+    torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
     optimizer.step()  # update weights first
     if scheduler is not None:
         scheduler.step()  # then adjust learning rate


### PR DESCRIPTION
## Summary
- correct gradient clipping in training_loop
- use logits only for classification and enforce long labels
- allow configuring delayed_reward_epochs in EnsembleModel
- flush accumulated gradients at the end of each epoch
- add regression tests for training loop and gradient accumulation

## Testing
- `pre-commit run --all-files`
- `pytest tests/test_training_loop_simple.py tests/test_ensemble_grad_accum.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687ed749242c83249fdddf2890d69e56