### PR TITLE
Update validation loss handling and GUI

### DIFF
--- a/artibot/gui_v2.py
+++ b/artibot/gui_v2.py
@@ -825,6 +825,8 @@ class TradingGUI:
         self.ax_loss.plot(x[: len(train_vals)], train_vals, label="Train", marker="o")
 
         val_vals = [np.nan if v is None else v for v in G.global_validation_loss]
+        # Without a validation loader ``global_validation_loss`` holds zeros,
+        # meaning the plotted line remains flat at the origin.
         val_vals = val_vals[:n]
         if pd is not None and any(not np.isnan(v) for v in val_vals):
             val_vals = pd.Series(val_vals).ewm(span=10).mean().tolist()

--- a/artibot/training.py
+++ b/artibot/training.py
@@ -73,7 +73,9 @@ def quick_fit(model: EnsembleModel, data: list[list[float]], epochs: int = 1) ->
     )
 
     for _ in range(epochs):
-        model.train_one_epoch(dl_train, dl_val, data, update_globals=False)
+        tl, vl = model.train_one_epoch(dl_train, dl_val, data, update_globals=False)
+        G.global_training_loss.append(tl)
+        G.global_validation_loss.append(vl if dl_val is not None else 0.0)
 
 
 logger = logging.getLogger(__name__)
@@ -387,10 +389,7 @@ def csv_training_thread(
                 G.global_holdout_sharpe = 0.0
                 G.global_holdout_max_drawdown = 0.0
             G.global_training_loss.append(tl)
-            if vl is not None:
-                G.global_validation_loss.append(vl)
-            else:
-                G.global_validation_loss.append(None)
+            G.global_validation_loss.append(vl if vl is not None else 0.0)
             smoothed_loss = smooth(G.global_training_loss)
             eq_vals = [b for _, b in G.global_equity_curve]
             smoothed_equity = smooth(eq_vals)
@@ -633,7 +632,7 @@ def csv_training_thread(
                         update_globals=update_globals,
                     )
                     G.global_training_loss.append(tl)
-                    G.global_validation_loss.append(vl)
+                    G.global_validation_loss.append(vl if vl is not None else 0.0)
                     writer.add_scalar("Loss/train", tl, ensemble.train_steps)
                     if vl is not None:
                         writer.add_scalar("Loss/val", vl, ensemble.train_steps)


### PR DESCRIPTION
## Summary
- track validation loss in `quick_fit` and training loops
- keep flat validation line when loader missing
- clarify GUI plot behavior for missing validation data

## Testing
- `pre-commit run --all-files`
- `pytest tests/validate_loss.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687f8b350f50832489bcbddc0a94d27a