### PR TITLE
Add Sortino, Omega & Calmar reward metrics

### DIFF
--- a/artibot/globals.py
+++ b/artibot/globals.py
@@ -136,6 +136,9 @@ global_profit_factor = 0.0
 global_avg_trade_duration = 0.0
 global_avg_win = 0.0
 global_avg_loss = 0.0
+global_sortino = 0.0
+global_omega = 0.0
+global_calmar = 0.0
 global_inactivity_penalty = None  # RL penalty when idle
 global_composite_reward = None  # most recent composite reward
 global_composite_reward_ema = 0.0
@@ -168,6 +171,11 @@ global_best_composite_reward = float("-inf")
 global_best_days_in_profit = None
 global_best_trade_details = []  # list of trades from the best run
 
+# Additional best risk metrics
+global_best_sortino = 0.0
+global_best_omega = 0.0
+global_best_calmar = 0.0
+
 # Global best hyperparameters:
 global_best_lr = None  # best learning rate so far
 global_best_wd = None  # best weight decay so far
@@ -183,6 +191,12 @@ use_sharpe_term = True  # include Sharpe ratio
 use_drawdown_term = True  # include drawdown term
 use_trade_term = True  # include trade count
 use_profit_days_term = True  # include days in profit
+use_sortino_term = False  # include Sortino ratio
+use_omega_term = False  # include Omega ratio
+use_calmar_term = False  # include Calmar ratio
+theta = 1.0  # Sortino weight
+phi = 1.0  # Omega weight
+chi = 1.0  # Calmar weight
 risk_filter_enabled = False  # training loss gating disabled by default
 
 ###############################################################################
@@ -530,6 +544,12 @@ def push_backtest_metrics(result: dict) -> None:
     global global_avg_trade_duration
     global global_avg_win
     global global_avg_loss
+    global global_sortino
+    global global_omega
+    global global_calmar
+    global global_best_sortino
+    global global_best_omega
+    global global_best_calmar
     global global_exposure_stats
     with state_lock:
         global_equity_curve = result["equity_curve"]
@@ -548,5 +568,14 @@ def push_backtest_metrics(result: dict) -> None:
         global_avg_trade_duration = result["avg_trade_duration"]
         global_avg_win = result.get("avg_win", 0.0)
         global_avg_loss = result.get("avg_loss", 0.0)
+        global_sortino = result.get("sortino", 0.0)
+        global_omega = result.get("omega", 0.0)
+        global_calmar = result.get("calmar", 0.0)
+        if global_sortino > global_best_sortino:
+            global_best_sortino = global_sortino
+        if global_omega > global_best_omega:
+            global_best_omega = global_omega
+        if global_calmar > global_best_calmar:
+            global_best_calmar = global_calmar
         global_exposure_stats = result.get("exposure", {})
     gui_event.set()

--- a/artibot/utils/reward_utils.py
+++ b/artibot/utils/reward_utils.py
@@ -21,3 +21,28 @@ def differential_sharpe(returns: torch.Tensor) -> torch.Tensor:
 
     dr = torch.diff(returns, prepend=returns[:1])
     return dr.mean() / (dr.std(unbiased=False) + 1e-6)
+
+
+def sortino_ratio(returns: torch.Tensor, target: float = 0.0) -> torch.Tensor:
+    """Return Sortino ratio of ``returns`` relative to ``target``.
+
+    Uses downside deviation to penalise negative volatility. A small
+    epsilon is added to avoid division by zero.
+    """
+    downside = torch.clamp(target - returns, min=0.0)
+    dd = downside.std(unbiased=False)
+    excess = returns.mean() - target
+    return excess / (dd + 1e-6)
+
+
+def omega_ratio(returns: torch.Tensor, threshold: float = 0.0) -> torch.Tensor:
+    """Return Omega ratio of ``returns`` around ``threshold``."""
+    gains = torch.clamp(returns - threshold, min=0.0).mean()
+    losses = torch.clamp(threshold - returns, min=0.0).mean()
+    return gains / (losses + 1e-6)
+
+
+def calmar_ratio(net_pct: float, max_drawdown: float, period_days: int) -> float:
+    """Return Calmar ratio based on annualised return and drawdown."""
+    annualised = net_pct / max(period_days / 365.0, 1e-6)
+    return annualised / (abs(max_drawdown) + 1e-6)

--- a/config/default.toml
+++ b/config/default.toml
@@ -3,3 +3,11 @@ heartbeat_interval = 120
 
 [risk_filter]
 enabled = true
+
+[reward]
+use_sortino_term = false
+use_omega_term = false
+use_calmar_term = false
+theta = 1.0
+phi = 1.0
+chi = 1.0

--- a/run_artibot.py
+++ b/run_artibot.py
@@ -204,6 +204,12 @@ def main() -> None:
         "use_drawdown_term": G.use_drawdown_term,
         "use_trade_term": G.use_trade_term,
         "use_profit_days_term": G.use_profit_days_term,
+        "use_sortino_term": G.use_sortino_term,
+        "use_omega_term": G.use_omega_term,
+        "use_calmar_term": G.use_calmar_term,
+        "theta": DEFAULT_CFG.get("reward", {}).get("theta", G.theta),
+        "phi": DEFAULT_CFG.get("reward", {}).get("phi", G.phi),
+        "chi": DEFAULT_CFG.get("reward", {}).get("chi", G.chi),
         "risk_filter": G.is_risk_filter_enabled(),
     }
     opts = startup_options_dialog(defaults)
@@ -226,6 +232,14 @@ def main() -> None:
     G.use_profit_days_term = bool(
         opts.get("use_profit_days_term", defaults["use_profit_days_term"])
     )
+    G.use_sortino_term = bool(
+        opts.get("use_sortino_term", defaults["use_sortino_term"])
+    )
+    G.use_omega_term = bool(opts.get("use_omega_term", defaults["use_omega_term"]))
+    G.use_calmar_term = bool(opts.get("use_calmar_term", defaults["use_calmar_term"]))
+    G.theta = float(opts.get("theta", defaults["theta"]))
+    G.phi = float(opts.get("phi", defaults["phi"]))
+    G.chi = float(opts.get("chi", defaults["chi"]))
     G.set_risk_filter_enabled(bool(opts.get("risk_filter", defaults["risk_filter"])))
 
     from artibot.utils import setup_logging

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -75,6 +75,7 @@ def test_robust_backtest_simple(monkeypatch):
     assert round(result["net_pct"], 2) == 0.93
     # Composite reward should heavily penalise draw-downs.
     assert result["composite_reward"] == pytest.approx(2.19581, rel=1e-3)
+    assert "sortino" in result and "omega" in result and "calmar" in result
 
 
 def test_robust_backtest_unbounded_reward(monkeypatch):

--- a/tests/test_reward_metrics.py
+++ b/tests/test_reward_metrics.py
@@ -1,0 +1,20 @@
+import torch
+import pytest
+from artibot.utils.reward_utils import sortino_ratio, omega_ratio, calmar_ratio
+
+
+def test_sortino_ratio_basic():
+    r = torch.tensor([0.1, -0.05, 0.2])
+    val = sortino_ratio(r)
+    assert val > 0
+
+
+def test_omega_ratio_basic():
+    r = torch.tensor([0.1, -0.1, 0.2])
+    val = omega_ratio(r)
+    assert val > 1
+
+
+def test_calmar_ratio_basic():
+    val = calmar_ratio(0.2, -0.1, 365)
+    assert val == pytest.approx(2.0, rel=1e-3)


### PR DESCRIPTION
## Summary
- implement Sortino, Omega and Calmar ratio helpers
- compute new risk metrics in backtests and add to reward formula
- expose metrics in globals and GUI
- allow configuring weights/flags for the new terms
- update default config and tests

## Testing
- `pre-commit run --files artibot/utils/reward_utils.py artibot/backtest.py artibot/globals.py artibot/gui_v2.py run_artibot.py config/default.toml tests/test_reward_metrics.py tests/test_backtest.py`
- `NO_HEAVY=1 pytest tests/test_reward_metrics.py -q`


------
https://chatgpt.com/codex/tasks/task_e_687fa8b0048c8324ad4d3c3bed819ad2