### PR TITLE
Remove default indicator periods

### DIFF
--- a/artibot/optuna_opt.py
+++ b/artibot/optuna_opt.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import fields
+from typing import get_args, get_origin
 from typing import Dict, Tuple
 import random
 
@@ -27,8 +28,15 @@ def _trial_indicator_params(trial: optuna.trial.Trial) -> IndicatorHyperparams:
     for f in fields(IndicatorHyperparams):
         if f.name.startswith("use_"):
             params[f.name] = trial.suggest_categorical(f.name, [True, False])
-        elif f.type is int:
-            params[f.name] = trial.suggest_int(f.name, 1, 200)
+        else:
+            ftype = f.type
+            origin = get_origin(ftype)
+            if origin is None:
+                if ftype is int:
+                    params[f.name] = trial.suggest_int(f.name, 1, 200)
+            else:
+                if int in get_args(ftype):
+                    params[f.name] = trial.suggest_int(f.name, 1, 200)
     return IndicatorHyperparams(**params)
 
 

--- a/tests/test_dynamic_tuning.py
+++ b/tests/test_dynamic_tuning.py
@@ -4,8 +4,8 @@ from artibot.rl import ACTION_KEYS, MetaTransformerRL
 
 
 def test_apply_action_syncs_globals():
-    hp = HyperParams()
-    ind_hp = IndicatorHyperparams()
+    ind_hp = IndicatorHyperparams(vortex_period=14, rsi_period=9)
+    hp = HyperParams(indicator_hp=ind_hp)
     agent = MetaTransformerRL(ensemble=None)
 
     act = {k: 0 for k in ACTION_KEYS}
@@ -37,8 +37,8 @@ def test_apply_action_syncs_globals():
 
 
 def test_toggle_ema_period_updates_globals():
-    hp = HyperParams()
-    ind_hp = IndicatorHyperparams()
+    ind_hp = IndicatorHyperparams(ema_period=20)
+    hp = HyperParams(indicator_hp=ind_hp)
     agent = MetaTransformerRL(ensemble=None)
 
     act = {k: 0 for k in ACTION_KEYS}

--- a/tests/test_feature_freeze.py
+++ b/tests/test_feature_freeze.py
@@ -8,7 +8,7 @@ from artibot.ensemble import EnsembleModel
 def test_actions_apply_after_warmup(monkeypatch):
     ens = EnsembleModel(device=torch.device("cpu"), n_models=1)
     agent = MetaTransformerRL(ens)
-    hp_inst = hp.HyperParams()
+    hp_inst = hp.HyperParams(indicator_hp=hp.IndicatorHyperparams(sma_period=10))
     ihp = hp_inst.indicator_hp
     sma_flag = ihp.use_sma
     period = ihp.sma_period

--- a/tests/test_hyperparams.py
+++ b/tests/test_hyperparams.py
@@ -8,3 +8,12 @@ def test_hyperparams_defaults():
     hp = hyperparams.HyperParams()
     assert 1e-4 < hp.learning_rate < 1e-3
     assert isinstance(hp.use_sma, bool)
+
+
+def test_indicator_defaults_none():
+    importlib.reload(hyperparams)
+    ihp = hyperparams.IndicatorHyperparams()
+    for f in hyperparams.fields(hyperparams.IndicatorHyperparams):
+        if f.name.startswith("use_"):
+            continue
+        assert getattr(ihp, f.name) is None

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -24,11 +24,28 @@ def test_cmf_length():
 
 def test_dataset_columns_flags():
     data = [[i, 1.0, 1.1, 0.9, 1.0, 1.0] for i in range(25)]
-    hp = IndicatorHyperparams()
+    base = {
+        "sma_period": 5,
+        "rsi_period": 10,
+        "macd_fast": 12,
+        "macd_slow": 26,
+        "macd_signal": 9,
+        "atr_period": 14,
+        "vortex_period": 14,
+        "cmf_period": 20,
+        "ema_period": 20,
+        "donchian_period": 20,
+        "kijun_period": 26,
+        "tenkan_period": 9,
+        "displacement": 26,
+    }
+    hp = IndicatorHyperparams(**base)
     ds = dataset.HourlyDataset(data, seq_len=3, indicator_hparams=hp)
     sample, _ = ds[0]
     base_cols = sample.shape[1]
-    hp_off = IndicatorHyperparams(use_atr=False, use_vortex=False, use_cmf=False)
+    hp_off = IndicatorHyperparams(
+        use_atr=False, use_vortex=False, use_cmf=False, **base
+    )
     ds_off = dataset.HourlyDataset(data, seq_len=3, indicator_hparams=hp_off)
     sample_off, _ = ds_off[0]
     assert sample_off.shape[1] < base_cols

--- a/tests/test_reward.py
+++ b/tests/test_reward.py
@@ -19,7 +19,21 @@ from artibot.hyperparams import IndicatorHyperparams  # noqa: E402
 class DummyEnsemble:
     def __init__(self):
         self.device = "cpu"
-        self.indicator_hparams = IndicatorHyperparams()
+        self.indicator_hparams = IndicatorHyperparams(
+            sma_period=5,
+            rsi_period=10,
+            macd_fast=12,
+            macd_slow=26,
+            macd_signal=9,
+            atr_period=14,
+            vortex_period=14,
+            cmf_period=20,
+            ema_period=20,
+            donchian_period=20,
+            kijun_period=26,
+            tenkan_period=9,
+            displacement=26,
+        )
 
     def vectorized_predict(self, windows_t, batch_size=512):
         preds = np.zeros(len(windows_t), dtype=np.int64)


### PR DESCRIPTION
## Summary
- let optimiser or config provide indicator periods
- clamp config overrides within 1..200
- adjust Optuna helper for optional period types
- update tests for new defaults

## Testing
- `pre-commit run --all-files`
- `NO_HEAVY=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'tensorboard')*

------
https://chatgpt.com/codex/tasks/task_e_68816b6afb3083248a0eaa4814613b98