### PR TITLE
Add warmup_steps parameter

### DIFF
--- a/artibot/backtest.py
+++ b/artibot/backtest.py
@@ -17,7 +17,7 @@ from .utils import (
     rolling_zscore,
 )
 from .dataset import trailing_sma, HourlyDataset
-from .hyperparams import IndicatorHyperparams
+from .hyperparams import IndicatorHyperparams, WARMUP_STEPS
 from . import indicators
 
 import artibot.globals as G
@@ -696,7 +696,12 @@ if __name__ == "__main__":
         train_mode=False,
     )
     n_features = ds_tmp[0][0].shape[1]
-    ens = EnsembleModel(device=get_device(), n_models=1, n_features=n_features)
+    ens = EnsembleModel(
+        device=get_device(),
+        n_models=1,
+        n_features=n_features,
+        warmup_steps=WARMUP_STEPS,
+    )
     stop = threading.Event()
     csv_training_thread(
         ens,

--- a/artibot/bot_app.py
+++ b/artibot/bot_app.py
@@ -32,7 +32,7 @@ def load_master_config(path: str = "master_config.json") -> dict:
 
 from .dataset import HourlyDataset, load_csv_hourly
 from .ensemble import EnsembleModel
-from .hyperparams import HyperParams, IndicatorHyperparams
+from .hyperparams import HyperParams, IndicatorHyperparams, WARMUP_STEPS
 import artibot.globals as G
 from .gui import TradingGUI, ask_use_prev_weights
 from .rl import MetaTransformerRL, meta_control_loop
@@ -175,6 +175,7 @@ def run_bot(max_epochs: int | None = None, *, overfit_toy: bool = False) -> None
         lr=1e-3,
         weight_decay=0.0,
         n_features=n_features,
+        warmup_steps=WARMUP_STEPS,
     )
     ensemble.indicator_hparams = indicator_hp
     ensemble.hp = HyperParams(indicator_hp=indicator_hp)

--- a/artibot/training.py
+++ b/artibot/training.py
@@ -968,7 +968,11 @@ def objective(trial: optuna.trial.Trial) -> float:
     )
     n_features = ds_tmp[0][0].shape[1]
     model = EnsembleModel(
-        device=get_device(), n_models=1, lr=params["lr"], n_features=n_features
+        device=get_device(),
+        n_models=1,
+        lr=params["lr"],
+        n_features=n_features,
+        warmup_steps=hyperparams.WARMUP_STEPS,
     )
     model.entropy_beta = params["entropy_beta"]
     model.indicator_hparams = indicator_hp
@@ -1043,7 +1047,11 @@ def run_hpo(n_trials: int = 50) -> dict:
     )
     n_features = ds_tmp[0][0].shape[1]
     model = EnsembleModel(
-        device=get_device(), n_models=1, lr=best.get("lr", 1e-4), n_features=n_features
+        device=get_device(),
+        n_models=1,
+        lr=best.get("lr", 1e-4),
+        n_features=n_features,
+        warmup_steps=hyperparams.WARMUP_STEPS,
     )
     model.entropy_beta = best.get("entropy_beta", 1e-4)
     model.indicator_hparams = indicator_hp
@@ -1091,7 +1099,9 @@ def walk_forward_backtest(data: list, train_window: int, test_horizon: int) -> l
         fold_idx += 1
         train_slice = data[start : start + train_window]
         test_slice = data[start + train_window : start + train_window + test_horizon]
-        model = EnsembleModel(device=get_device(), n_models=1)
+        model = EnsembleModel(
+            device=get_device(), n_models=1, warmup_steps=hyperparams.WARMUP_STEPS
+        )
         quick_fit(model, train_slice, epochs=1)
         metrics = robust_backtest(model, test_slice)
         if metrics.get("trades", 0) == 0:

--- a/artibot/validation.py
+++ b/artibot/validation.py
@@ -17,7 +17,7 @@ import artibot.globals as G
 from .backtest import robust_backtest
 from .dataset import load_csv_hourly, HourlyDataset
 from .ensemble import EnsembleModel
-from .hyperparams import HyperParams, IndicatorHyperparams
+from .hyperparams import HyperParams, IndicatorHyperparams, WARMUP_STEPS
 from .training import csv_training_thread
 from artibot.core.device import get_device
 
@@ -95,6 +95,7 @@ def walk_forward_analysis(csv_path: str, config: dict) -> list[dict]:
         lr=3e-4,
         weight_decay=1e-4,
         n_features=n_features,
+        warmup_steps=WARMUP_STEPS,
     )
     ensemble.indicator_hparams = indicator_hp
     ensemble.hp = HyperParams(indicator_hp=indicator_hp)

--- a/artibot/walk_forward_opt.py
+++ b/artibot/walk_forward_opt.py
@@ -10,7 +10,7 @@ import pandas as pd
 from sklearn.base import BaseEstimator
 
 from .ensemble import EnsembleModel
-from .hyperparams import IndicatorHyperparams
+from .hyperparams import IndicatorHyperparams, WARMUP_STEPS
 from .training import csv_training_thread
 from .backtest import robust_backtest
 from .optuna_opt import run_bohb
@@ -50,6 +50,7 @@ class EnsembleEstimator(BaseEstimator):
             lr=self.lr,
             weight_decay=self.weight_decay,
             n_models=1,
+            warmup_steps=WARMUP_STEPS,
         )
         self.model_.indicator_hparams = self.indicator_hp
         stop = threading.Event()

--- a/run_artibot.py
+++ b/run_artibot.py
@@ -169,6 +169,7 @@ def build_model(
     entropy_beta: float | None = None,
 ) -> "EnsembleModel":
     """Return an :class:`EnsembleModel` configured with HPO params."""
+    from artibot.hyperparams import WARMUP_STEPS
 
     model = EnsembleModel(
         device=device,
@@ -178,6 +179,7 @@ def build_model(
         n_features=n_features,
         total_steps=10000,
         grad_accum_steps=4,
+        warmup_steps=WARMUP_STEPS,
     )
     if entropy_beta is not None:
         model.entropy_beta = entropy_beta

--- a/scripts/smoke.py
+++ b/scripts/smoke.py
@@ -45,6 +45,8 @@ def main() -> None:
     hp = HyperParams(indicator_hp=indicator_hp)
     if args.learning_rate:
         hp.learning_rate = args.learning_rate
+    from artibot.hyperparams import WARMUP_STEPS
+
     ensemble = EnsembleModel(
         device=get_device(),
         n_models=1,
@@ -53,6 +55,7 @@ def main() -> None:
         n_features=n_features,
         total_steps=2000,
         grad_accum_steps=4,
+        warmup_steps=WARMUP_STEPS,
     )
     ensemble.indicator_hparams = indicator_hp
     ensemble.hp = hp


### PR DESCRIPTION
## Summary
- support `warmup_steps` in `EnsembleModel`
- activate RL based on `warmup_steps`
- pass new argument when constructing ensembles
- log whether RL loss is active

## Testing
- `pre-commit run --all-files`
- `pytest -q tests/test_device.py`

------
https://chatgpt.com/codex/tasks/task_e_688171b289ac8324bcb87d0e71e720f5