### PR TITLE
Set indicator hyperparams defaults

### DIFF
--- a/tests/test_hyperparams.py
+++ b/tests/test_hyperparams.py
@@ -10,10 +10,12 @@ def test_hyperparams_defaults():
     assert isinstance(hp.use_sma, bool)
 
 
-def test_indicator_defaults_none():
+def test_indicator_defaults_one_and_true():
     importlib.reload(hyperparams)
     ihp = hyperparams.IndicatorHyperparams()
     for f in hyperparams.fields(hyperparams.IndicatorHyperparams):
+        val = getattr(ihp, f.name)
         if f.name.startswith("use_"):
-            continue
-        assert getattr(ihp, f.name) is None
+            assert val is True
+        else:
+            assert val == 1


### PR DESCRIPTION
## Summary
- default indicator period values to `1`
- turn on all indicator toggle flags by default
- log indicator hyperparameters on init
- update indicator defaults test

## Testing
- `pre-commit run --files artibot/hyperparams.py tests/test_hyperparams.py`
- `pytest tests/test_hyperparams.py::test_indicator_defaults_one_and_true -q --no-heavy`


------
https://chatgpt.com/codex/tasks/task_e_6881775702908324903f0933eb4debf7