### PR TITLE
Use composite reward in Optuna objective

### DIFF
--- a/artibot/feature_store.py
+++ b/artibot/feature_store.py
@@ -18,6 +18,7 @@ import duckdb
 import threading
 import numpy as np
 import json
+import logging
 import pathlib
 
 from .constants import FEATURE_DIMENSION
@@ -46,6 +47,7 @@ def freeze_feature_dim(dim: int) -> int:
     if _STORE.exists():
         dim = max(dim, json.load(_STORE.open())["dim"])
     json.dump({"dim": dim}, _STORE.open("w"))
+    logging.info("FROZEN_DIM %d", dim)
     return dim
 
 

--- a/artibot/optuna_opt.py
+++ b/artibot/optuna_opt.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 from dataclasses import fields
-from typing import get_args, get_origin
-from typing import Dict, Tuple
-import random
+from typing import Dict, Tuple, get_args, get_origin
+import logging
+import os
+
+import torch
 
 import optuna
 
@@ -16,6 +18,9 @@ except Exception:  # pragma: no cover - stubbed optuna
     TPESampler = HyperbandPruner = None
 
 from .hyperparams import IndicatorHyperparams
+from .ensemble import EnsembleModel
+from .backtest import robust_backtest
+from .dataset import load_csv_hourly, HourlyDataset
 
 
 _DEF_LR = 1e-3
@@ -40,21 +45,54 @@ def _trial_indicator_params(trial: optuna.trial.Trial) -> IndicatorHyperparams:
     return IndicatorHyperparams(**params)
 
 
+_CSV_PATH = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "Gemini_BTCUSD_1h.csv")
+)
+
+
+def _quick_backtest(
+    hp: IndicatorHyperparams, bars: int = 90
+) -> tuple[float, float, float]:
+    """Run a light-weight backtest and return reward metrics."""
+
+    data = load_csv_hourly(_CSV_PATH)
+    if len(data) > bars:
+        data = data[-bars:]
+    ds = HourlyDataset(data, seq_len=24, indicator_hparams=hp, train_mode=False)
+    n_features = ds[0][0].shape[-1]
+    model = EnsembleModel(
+        device=torch.device("cpu"),
+        n_models=1,
+        n_features=n_features,
+    )
+    model.indicator_hparams = hp
+    result = robust_backtest(model, data)
+    return (
+        result.get("composite_reward", 0.0),
+        result.get("net_pct", 0.0),
+        result.get("sharpe", 0.0),
+    )
+
+
 def _objective(trial: optuna.trial.Trial) -> float:
-    """Dummy objective reporting two steps for pruning."""
+    """Evaluate indicator parameters using a short backtest."""
+
     hp = _trial_indicator_params(trial)
-    lr = trial.suggest_float("learning_rate", 1e-5, 1e-2, log=True)
-    wd = trial.suggest_float("weight_decay", 1e-6, 1e-2, log=True)
-    # quick evaluation placeholder
-    score = random.random()
-    trial.report(score, step=0)
-    if trial.should_prune():
-        raise optuna.TrialPruned()
-    score += random.random() * 0.1
-    trial.report(score, step=1)
+    trial_lr = trial.suggest_float("learning_rate", 1e-5, 1e-2, log=True)
+    trial_wd = trial.suggest_float("weight_decay", 1e-6, 1e-2, log=True)
+    comp_reward, net_pct, sharpe = _quick_backtest(hp, bars=90)
+    score = comp_reward if comp_reward > 0 else -1.0
+    logging.info(
+        "Optuna trial: hp=%s, net_pct=%.2f, sharpe=%.2f, comp_reward=%.3f, returned=%.3f",
+        hp,
+        net_pct,
+        sharpe,
+        comp_reward,
+        score,
+    )
     trial.set_user_attr("indicator_hp", hp)
-    trial.set_user_attr("learning_rate", lr)
-    trial.set_user_attr("weight_decay", wd)
+    trial.set_user_attr("learning_rate", trial_lr)
+    trial.set_user_attr("weight_decay", trial_wd)
     return score
 
 

--- a/artibot/rl.py
+++ b/artibot/rl.py
@@ -390,7 +390,8 @@ class MetaTransformerRL:
             for p in self.model.parameters():
                 if p.requires_grad:
                     p.grad = torch.zeros_like(p)
-        torch.nn.utils.clip_grad_norm_(self.model.parameters(), 1.0)
+        grad_norm = torch.nn.utils.clip_grad_norm_(self.model.parameters(), 1.0)
+        logging.debug("PPO_GRAD_NORM %.6f", float(grad_norm))
         self.opt.step()
         if self.scheduler is not None:
             try:


### PR DESCRIPTION
## Summary
- run a small backtest inside `optuna_opt._objective`
- log frozen feature dimension in the feature store
- record PPO gradient norm for debugging

## Testing
- `pre-commit run --all-files`
- `pytest tests/test_optuna_opt.py::test_bohb_range -q`

------
https://chatgpt.com/codex/tasks/task_e_6881813493788324ad5fbfbdb8943595