### PR TITLE
Fix indicator HP persistence

### DIFF
--- a/artibot/ensemble.py
+++ b/artibot/ensemble.py
@@ -239,8 +239,8 @@ class EnsembleModel(nn.Module):
         self.device = device
         self.weights_path = weights_path
         # use config defaults for all indicator settings
-        self.indicator_hparams = IndicatorHyperparams()
-        self.hp = HyperParams(indicator_hp=self.indicator_hparams)
+        self._indicator_hparams = IndicatorHyperparams()
+        self.hp = HyperParams(indicator_hp=self._indicator_hparams)
         if lr is not None:
             self.hp.learning_rate = lr
 
@@ -316,6 +316,21 @@ class EnsembleModel(nn.Module):
 
         self.grad_accum_steps = grad_accum_steps
         self.total_steps = total_steps
+
+    # ------------------------------------------------------------------
+    @property
+    def indicator_hparams(self) -> IndicatorHyperparams:
+        """Return indicator hyper-parameters."""
+
+        return self._indicator_hparams
+
+    @indicator_hparams.setter
+    def indicator_hparams(self, hp: IndicatorHyperparams) -> None:
+        """Synchronise indicator settings across sub-objects."""
+
+        self._indicator_hparams = hp
+        if hasattr(self, "hp"):
+            self.hp.indicator_hp = hp
 
     def _align_features(self, x: torch.Tensor) -> torch.Tensor:
         """Validate feature dimension and zero disabled columns."""

--- a/artibot/training.py
+++ b/artibot/training.py
@@ -1055,7 +1055,6 @@ def run_hpo(n_trials: int = 50) -> dict:
     )
     model.entropy_beta = best.get("entropy_beta", 1e-4)
     model.indicator_hparams = indicator_hp
-    model.hp.indicator_hp = indicator_hp
     quick_fit(model, data, epochs=1)
     full_result = robust_backtest(model, data, indicator_hp=model.indicator_hparams)
     if full_result.get("trades", 0) == 0:


### PR DESCRIPTION
## Summary
- sync EnsembleModel indicator hyperparams with HyperParams via property
- remove manual sync in training loop

## Testing
- `pre-commit run --all-files`
- `pytest tests/test_backtest.py::test_indicator_hp_persists -q`


------
https://chatgpt.com/codex/tasks/task_e_68842ff1b4648324b6e5998c765a067a