### PR TITLE
Persist indicator hyperparams

### DIFF
--- a/artibot/bot_app.py
+++ b/artibot/bot_app.py
@@ -32,7 +32,7 @@ def load_master_config(path: str = "master_config.json") -> dict:
 
 from .dataset import HourlyDataset, load_csv_hourly
 from .ensemble import EnsembleModel
-from .hyperparams import HyperParams, IndicatorHyperparams, WARMUP_STEPS
+from .hyperparams import IndicatorHyperparams, WARMUP_STEPS
 import artibot.globals as G
 from .gui import TradingGUI, ask_use_prev_weights
 from .rl import MetaTransformerRL, meta_control_loop
@@ -176,9 +176,8 @@ def run_bot(max_epochs: int | None = None, *, overfit_toy: bool = False) -> None
         weight_decay=0.0,
         n_features=n_features,
         warmup_steps=WARMUP_STEPS,
+        indicator_hp=indicator_hp,
     )
-    ensemble.indicator_hparams = indicator_hp
-    ensemble.hp = HyperParams(indicator_hp=indicator_hp)
     if hasattr(torch, "set_float32_matmul_precision"):
         torch.set_float32_matmul_precision("high")
     from artibot.utils.safe_compile import safe_compile

--- a/artibot/validation.py
+++ b/artibot/validation.py
@@ -17,7 +17,7 @@ import artibot.globals as G
 from .backtest import robust_backtest
 from .dataset import load_csv_hourly, HourlyDataset
 from .ensemble import EnsembleModel
-from .hyperparams import HyperParams, IndicatorHyperparams, WARMUP_STEPS
+from .hyperparams import IndicatorHyperparams, WARMUP_STEPS
 from .training import csv_training_thread
 from artibot.core.device import get_device
 
@@ -96,9 +96,8 @@ def walk_forward_analysis(csv_path: str, config: dict) -> list[dict]:
         weight_decay=1e-4,
         n_features=n_features,
         warmup_steps=WARMUP_STEPS,
+        indicator_hp=indicator_hp,
     )
-    ensemble.indicator_hparams = indicator_hp
-    ensemble.hp = HyperParams(indicator_hp=indicator_hp)
     if hasattr(torch, "set_float32_matmul_precision"):
         torch.set_float32_matmul_precision("high")
     from artibot.utils.safe_compile import safe_compile

--- a/run_artibot.py
+++ b/run_artibot.py
@@ -14,6 +14,7 @@ from artibot.utils.torch_threads import set_threads
 from artibot.gui import startup_options_dialog
 from dataclasses import fields
 from artibot.ensemble import EnsembleModel
+from artibot.hyperparams import IndicatorHyperparams
 import artibot.globals as G
 
 import os
@@ -168,6 +169,7 @@ def build_model(
     lr: float = 1e-3,
     entropy_beta: float | None = None,
     warmup_steps: int | None = None,
+    indicator_hp: IndicatorHyperparams | None = None,
 ) -> "EnsembleModel":
     """Return an :class:`EnsembleModel` configured with HPO params."""
     from artibot.hyperparams import WARMUP_STEPS
@@ -181,6 +183,7 @@ def build_model(
         total_steps=10000,
         grad_accum_steps=4,
         warmup_steps=warmup_steps or WARMUP_STEPS,
+        indicator_hp=indicator_hp,
     )
     if entropy_beta is not None:
         model.entropy_beta = entropy_beta
@@ -271,7 +274,7 @@ def main() -> None:
     from artibot.utils import setup_logging
     from artibot.core.device import get_device
     from artibot.dataset import HourlyDataset, load_csv_hourly
-    from artibot.hyperparams import HyperParams, IndicatorHyperparams
+    from artibot.hyperparams import IndicatorHyperparams
     from artibot.training import (
         PhemexConnector,
         csv_training_thread,
@@ -367,9 +370,8 @@ def main() -> None:
             lr=lr,
             entropy_beta=entropy_beta,
             warmup_steps=int(opts.get("warmup_steps", defaults["warmup_steps"])),
+            indicator_hp=indicator_hp,
         )
-        ensemble.indicator_hparams = indicator_hp
-        ensemble.hp = HyperParams(indicator_hp=indicator_hp)
 
         weights_dir = os.path.abspath(
             os.path.expanduser(CONFIG.get("WEIGHTS_DIR", "weights"))


### PR DESCRIPTION
## Summary
- allow passing `IndicatorHyperparams` to `EnsembleModel`
- store indicator parameters in weight checkpoints
- restore them when loading
- simplify construction in `run_artibot`, `bot_app`, and `validation`
- update test for new checkpoint contents

## Testing
- `pre-commit run --all-files`
- `pytest tests/test_best_weights_load.py -q --no-heavy`

------
https://chatgpt.com/codex/tasks/task_e_68843b7938008324b72c6f1dc5a65695