### PR TITLE
Pass tuned indicator HP to validation

### DIFF
--- a/run_artibot.py
+++ b/run_artibot.py
@@ -441,7 +441,10 @@ def main() -> None:
         meta_th.start()
 
         validate_th = threading.Thread(
-            target=lambda: validate_and_gate(csv_path, CONFIG), daemon=True
+            target=lambda: validate_and_gate(
+                csv_path, CONFIG, indicator_hp=indicator_hp
+            ),
+            daemon=True,
         )
         validate_th.start()
 


### PR DESCRIPTION
## Summary
- use tuned indicator HP in validation thread
- allow `validate_and_gate`, `walk_forward_analysis`, and `schedule_monthly_validation` to accept optional indicator hyperparams

## Testing
- `pre-commit run --all-files`
- `pytest -q --no-heavy tests/test_validation.py::test_schedule_monthly_validation`

------
https://chatgpt.com/codex/tasks/task_e_6884b650886883248e4be0c3e84205d5