### PR TITLE
Suppress default hyperparam logs

### DIFF
--- a/artibot/hyperparams.py
+++ b/artibot/hyperparams.py
@@ -155,10 +155,16 @@ class IndicatorHyperparams:
                     except Exception:
                         pass
 
-        logging.info(
-            "Indicator hyperparams: %s",
-            {f.name: getattr(self, f.name) for f in fields(self)},
+        params = {f.name: getattr(self, f.name) for f in fields(self)}
+        all_default = all(
+            (isinstance(val, bool) and val is True)
+            or (isinstance(val, int) and val == 1)
+            for val in params.values()
         )
+        if not all_default:
+            logging.info("Indicator hyperparams: %s", params)
+        else:
+            logging.debug("Indicator hyperparams (default): %s", params)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- log indicator hyperparams only when non-default

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6884b8d31f78832482dfcd194a73421a