### PR TITLE
Fix indicator freeze and warmup

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,9 @@ Answer `n` at the startup prompt or set `LIVE_TRADING` to `false` in the config
 to route orders to the Phemex sandbox while still running the full trading
 cycle. Respond `y` for real trades on the live exchange.
 
+When running in sandbox or during back-tests leave `--freeze_features` enabled so
+the RL agent doesn't alter indicator selection between folds.
+
 ### Dashboard
 
 The Tkinter GUI displays several live metrics. The **Attention Weights** tab

--- a/artibot/backtest.py
+++ b/artibot/backtest.py
@@ -17,7 +17,8 @@ from .utils import (
     rolling_zscore,
 )
 from .dataset import trailing_sma, HourlyDataset
-from .hyperparams import IndicatorHyperparams, WARMUP_STEPS
+from .hyperparams import IndicatorHyperparams
+from .constants import WARMUP_STEPS
 from . import indicators
 
 import artibot.globals as G

--- a/artibot/constants.py
+++ b/artibot/constants.py
@@ -2,4 +2,8 @@
 
 FEATURE_DIMENSION = 16
 
-__all__ = ["FEATURE_DIMENSION"]
+# Default number of mini-batches before RL tweaks activate.
+# Can be overridden via the ``--warmup_steps`` CLI flag.
+WARMUP_STEPS = 500
+
+__all__ = ["FEATURE_DIMENSION", "WARMUP_STEPS"]

--- a/artibot/ensemble.py
+++ b/artibot/ensemble.py
@@ -238,6 +238,7 @@ class EnsembleModel(nn.Module):
         delayed_reward_epochs: int = 0,
         warmup_steps: int | None = None,
         indicator_hp: IndicatorHyperparams | None = None,
+        freeze_features: bool | None = None,
     ) -> None:
         super().__init__()
         device = torch.device(device) if device is not None else get_device()
@@ -248,6 +249,8 @@ class EnsembleModel(nn.Module):
             indicator_hp if indicator_hp is not None else IndicatorHyperparams()
         )
         self.hp = HyperParams(indicator_hp=self._indicator_hparams)
+        if freeze_features is not None:
+            self.hp.freeze_features = freeze_features
         if lr is not None:
             self.hp.learning_rate = lr
 
@@ -340,6 +343,12 @@ class EnsembleModel(nn.Module):
 
         self._indicator_hparams = hp
         self.hp.indicator_hp = hp
+
+    @property
+    def freeze_features(self) -> bool:
+        """Return whether indicator features are frozen."""
+
+        return self.hp.freeze_features
 
     def _align_features(self, x: torch.Tensor) -> torch.Tensor:
         """Validate feature dimension and zero disabled columns."""

--- a/artibot/optuna_opt.py
+++ b/artibot/optuna_opt.py
@@ -64,8 +64,9 @@ def _quick_backtest(
         device=torch.device("cpu"),
         n_models=1,
         n_features=n_features,
+        indicator_hp=hp,
+        freeze_features=True,
     )
-    model.indicator_hparams = hp
     result = robust_backtest(model, data, indicator_hp=hp)
     return (
         result.get("composite_reward", 0.0),

--- a/artibot/rl.py
+++ b/artibot/rl.py
@@ -128,6 +128,8 @@ class TransformerMetaAgent(nn.Module):
 
 
 class MetaTransformerRL:
+    _instances: list["MetaTransformerRL"] = []
+
     def __init__(
         self,
         ensemble,
@@ -183,6 +185,7 @@ class MetaTransformerRL:
         self.steps = 0
         self.last_improvement = 0
         self.batch_buffer: list[tuple] = []
+        self.__class__._instances.append(self)
 
     def _to_device(self, *tensors):
         """Move tensors to ``self.device``.
@@ -202,6 +205,19 @@ class MetaTransformerRL:
         if not hasattr(self._model, "state_dim"):
             self._model.state_dim = self.state_dim
         self._model.to(self.device, non_blocking=True)
+
+    @classmethod
+    def reset_policy(cls) -> None:
+        """Clear optimizer state and step counters for all agents."""
+
+        for inst in cls._instances:
+            inst.steps = 0
+            inst.low_kl_count = 0
+            inst.last_improvement = 0
+            inst.batch_buffer.clear()
+            if hasattr(inst, "opt"):
+                inst.opt.state.clear()
+        cls._instances.clear()
 
     def pick_action(self, state_np):
         """Return an action dictionary with PPO-compatible log probability."""
@@ -297,12 +313,13 @@ class MetaTransformerRL:
         self.prev_logprob = logp.detach()
         self.prev_action_idx = action_idx
         filtered = {}
-        freeze = hyperparams.should_freeze_features(G.get_warmup_step())
+        freeze = hyperparams.should_freeze_features(G.get_warmup_step()) or getattr(
+            self.ensemble.hp, "freeze_features", False
+        )
         for action_name, val in act.items():
             if freeze and (
                 action_name.startswith("toggle_")
-                or action_name.endswith("_period")
-                or action_name.endswith("_frac")
+                or action_name.endswith("_period_delta")
             ):
                 continue
             if action_name not in hyperparams.ALLOWED_META_ACTIONS:
@@ -419,12 +436,13 @@ class MetaTransformerRL:
             logging.info("FEATURE_IMPORTANCE %s %.3f", k, prob)
 
         filtered = {}
-        freeze = hyperparams.should_freeze_features(G.get_warmup_step())
+        freeze = hyperparams.should_freeze_features(G.get_warmup_step()) or getattr(
+            hp, "freeze_features", False
+        )
         for action_name, val in act.items():
             if freeze and (
                 action_name.startswith("toggle_")
-                or action_name.endswith("_period")
-                or action_name.endswith("_frac")
+                or action_name.endswith("_period_delta")
             ):
                 continue
             if action_name not in hyperparams.ALLOWED_META_ACTIONS:
@@ -789,12 +807,13 @@ def meta_control_loop(
             state = np.nan_to_num(state, nan=0.0, posinf=1e6, neginf=-1e6)
             act, logp, val_s = agent.pick_action(state)
             filtered = {}
-            freeze = hyperparams.should_freeze_features(G.get_warmup_step())
+            freeze = hyperparams.should_freeze_features(G.get_warmup_step()) or getattr(
+                hp, "freeze_features", False
+            )
             for action_name, val in act.items():
                 if freeze and (
                     action_name.startswith("toggle_")
-                    or action_name.endswith("_period")
-                    or action_name.endswith("_frac")
+                    or action_name.endswith("_period_delta")
                 ):
                     continue
                 if action_name not in hyperparams.ALLOWED_META_ACTIONS:

--- a/artibot/training.py
+++ b/artibot/training.py
@@ -17,7 +17,7 @@ import threading
 import os
 from pathlib import Path
 
-from dataclasses import fields
+from dataclasses import fields, asdict
 from .dataset import HourlyDataset, trailing_sma, load_csv_hourly
 from .ensemble import reject_if_risky, EnsembleModel, update_best
 from .hyperparams import IndicatorHyperparams
@@ -226,7 +226,13 @@ def csv_training_thread(
 
         # Perform walk-forward validation to establish holdout metrics
         one_month = 24 * 30
-        walk_results = walk_forward_backtest(train_data, 12 * one_month, one_month)
+        walk_results = walk_forward_backtest(
+            train_data,
+            12 * one_month,
+            one_month,
+            indicator_hp=ensemble.indicator_hparams,
+            freeze_features=True,
+        )
         if walk_results:
             mean_sharpe = float(np.mean([r.get("sharpe", 0.0) for r in walk_results]))
             mean_dd = float(np.mean([r.get("max_drawdown", 0.0) for r in walk_results]))
@@ -465,7 +471,8 @@ def csv_training_thread(
                 },
             )
 
-            from artibot.hyperparams import RISK_FILTER, WARMUP_STEPS
+            from artibot.hyperparams import RISK_FILTER
+            from artibot.constants import WARMUP_STEPS
 
             if G.get_warmup_step() >= WARMUP_STEPS:
                 RISK_FILTER["MIN_REWARD"] = 0.5
@@ -974,6 +981,7 @@ def objective(trial: optuna.trial.Trial) -> float:
         n_features=n_features,
         warmup_steps=G.warmup_steps,
         indicator_hp=indicator_hp,
+        freeze_features=True,
     )
     model.entropy_beta = params["entropy_beta"]
     stop = threading.Event()
@@ -1053,6 +1061,7 @@ def run_hpo(n_trials: int = 50) -> dict:
         n_features=n_features,
         warmup_steps=G.warmup_steps,
         indicator_hp=indicator_hp,
+        freeze_features=True,
     )
     model.entropy_beta = best.get("entropy_beta", 1e-4)
     quick_fit(model, data, epochs=1)
@@ -1078,7 +1087,14 @@ def run_hpo(n_trials: int = 50) -> dict:
     return best
 
 
-def walk_forward_backtest(data: list, train_window: int, test_horizon: int) -> list:
+def walk_forward_backtest(
+    data: list,
+    train_window: int,
+    test_horizon: int,
+    *,
+    indicator_hp: IndicatorHyperparams | None = None,
+    freeze_features: bool = True,
+) -> list:
     """Perform walk-forward validation across ``data``."""
 
     logging.info(">>> ENTERING DEFCON 4: Walk Forward Evaluation")
@@ -1099,11 +1115,23 @@ def walk_forward_backtest(data: list, train_window: int, test_horizon: int) -> l
         fold_idx += 1
         train_slice = data[start : start + train_window]
         test_slice = data[start + train_window : start + train_window + test_horizon]
+        if indicator_hp is None:
+            indicator_hp = IndicatorHyperparams()
+        logging.info(
+            "USING_INDICATOR_HP fold=%d %s",
+            fold_idx,
+            asdict(indicator_hp),
+        )
+        from artibot.rl import MetaTransformerRL
+
+        G.global_step = 0
+        MetaTransformerRL.reset_policy()
         model = EnsembleModel(
             device=get_device(),
             n_models=1,
             warmup_steps=G.warmup_steps,
-            indicator_hp=IndicatorHyperparams(),
+            indicator_hp=indicator_hp,
+            freeze_features=freeze_features,
         )
         quick_fit(model, train_slice, epochs=1)
         metrics = robust_backtest(

--- a/artibot/validation.py
+++ b/artibot/validation.py
@@ -2,6 +2,7 @@
 
 import threading
 from typing import Iterable
+from dataclasses import asdict
 import torch
 
 import numpy as np
@@ -17,7 +18,8 @@ import artibot.globals as G
 from .backtest import robust_backtest
 from .dataset import load_csv_hourly, HourlyDataset
 from .ensemble import EnsembleModel
-from .hyperparams import IndicatorHyperparams, WARMUP_STEPS
+from .hyperparams import IndicatorHyperparams
+from .constants import WARMUP_STEPS
 from .training import csv_training_thread
 from artibot.core.device import get_device
 
@@ -102,6 +104,7 @@ def walk_forward_analysis(
         n_features=n_features,
         warmup_steps=WARMUP_STEPS,
         indicator_hp=indicator_hp,
+        freeze_features=True,
     )
     if hasattr(torch, "set_float32_matmul_precision"):
         torch.set_float32_matmul_precision("high")
@@ -112,6 +115,11 @@ def walk_forward_analysis(
     one_month = YEAR_HOURS // 12
     seven_months = 7 * one_month
     for start in range(0, len(data) - seven_months + 1, one_month):
+        logging.info(
+            "USING_INDICATOR_HP fold=%d %s",
+            (start // one_month) + 1,
+            asdict(indicator_hp),
+        )
         train = data[start : start + 6 * one_month]
         test = data[start + 6 * one_month : start + seven_months]
         if len(test) < one_month:

--- a/artibot/walk_forward_opt.py
+++ b/artibot/walk_forward_opt.py
@@ -10,7 +10,8 @@ import pandas as pd
 from sklearn.base import BaseEstimator
 
 from .ensemble import EnsembleModel
-from .hyperparams import IndicatorHyperparams, WARMUP_STEPS
+from .hyperparams import IndicatorHyperparams
+from .constants import WARMUP_STEPS
 from .training import csv_training_thread
 from .backtest import robust_backtest
 from .optuna_opt import run_bohb
@@ -52,8 +53,8 @@ class EnsembleEstimator(BaseEstimator):
             n_models=1,
             warmup_steps=WARMUP_STEPS,
             indicator_hp=self.indicator_hp,
+            freeze_features=True,
         )
-        self.model_.indicator_hparams = self.indicator_hp
         stop = threading.Event()
         csv_training_thread(
             self.model_,

--- a/config/default.toml
+++ b/config/default.toml
@@ -17,4 +17,4 @@ beta = 0.6
 theta = 0.6
 phi = 0.5
 chi = 0.5
-WARMUP_STEPS = 0
+WARMUP_STEPS = 500

--- a/run_artibot.py
+++ b/run_artibot.py
@@ -170,9 +170,10 @@ def build_model(
     entropy_beta: float | None = None,
     warmup_steps: int | None = None,
     indicator_hp: IndicatorHyperparams | None = None,
+    freeze_features: bool | None = None,
 ) -> "EnsembleModel":
     """Return an :class:`EnsembleModel` configured with HPO params."""
-    from artibot.hyperparams import WARMUP_STEPS
+    from artibot.constants import WARMUP_STEPS
 
     model = EnsembleModel(
         device=device,
@@ -184,6 +185,7 @@ def build_model(
         grad_accum_steps=4,
         warmup_steps=warmup_steps or WARMUP_STEPS,
         indicator_hp=indicator_hp,
+        freeze_features=freeze_features,
     )
     if entropy_beta is not None:
         model.entropy_beta = entropy_beta
@@ -371,6 +373,7 @@ def main() -> None:
             entropy_beta=entropy_beta,
             warmup_steps=int(opts.get("warmup_steps", defaults["warmup_steps"])),
             indicator_hp=indicator_hp,
+            freeze_features=True,
         )
 
         weights_dir = os.path.abspath(

--- a/scripts/smoke.py
+++ b/scripts/smoke.py
@@ -45,7 +45,7 @@ def main() -> None:
     hp = HyperParams(indicator_hp=indicator_hp)
     if args.learning_rate:
         hp.learning_rate = args.learning_rate
-    from artibot.hyperparams import WARMUP_STEPS
+    from artibot.constants import WARMUP_STEPS
 
     ensemble = EnsembleModel(
         device=get_device(),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -214,8 +214,12 @@ def pytest_configure(config):
 
     if "pandas" not in sys.modules:
         pd = types.ModuleType("pandas")
+        pd.__spec__ = ModuleSpec("pandas", loader=None)
         pd.Series = lambda *a, **k: object()
         pd.DataFrame = lambda *a, **k: object()
+        pd.to_datetime = lambda x, unit="s": types.SimpleNamespace(
+            strftime=lambda f: "2020-01"
+        )
         sys.modules["pandas"] = pd
 
     if "transformers" not in sys.modules:
@@ -235,7 +239,9 @@ def pytest_configure(config):
 
     if "sklearn" not in sys.modules:
         sk = types.ModuleType("sklearn")
+        sk.__spec__ = ModuleSpec("sklearn", loader=None)
         impute_mod = types.ModuleType("sklearn.impute")
+        impute_mod.__spec__ = ModuleSpec("sklearn.impute", loader=None)
         impute_mod.KNNImputer = object
         sk.impute = impute_mod
         sys.modules["sklearn"] = sk

--- a/tests/test_indicator_flow.py
+++ b/tests/test_indicator_flow.py
@@ -1,0 +1,28 @@
+
+import artibot.training as training
+from artibot.hyperparams import IndicatorHyperparams
+from artibot.ensemble import EnsembleModel
+import artibot.globals as G
+import torch
+
+
+def test_indicator_flow(monkeypatch):
+    periods = []
+
+    def fake_quick_fit(*a, **k):
+        pass
+
+    def fake_backtest(model, data, indicator_hp=None):
+        periods.append(indicator_hp.sma_period)
+        return {"trades": 1, "net_pct": 0.0, "composite_reward": 0.0, "sharpe": 0.0, "max_drawdown": 0.0}
+
+    monkeypatch.setattr(training, "quick_fit", fake_quick_fit)
+    monkeypatch.setattr(training, "robust_backtest", fake_backtest)
+    monkeypatch.setattr(G, "push_backtest_metrics", lambda *a, **k: None)
+
+    data = [[i, 0, 0, 0, 0, 0] for i in range(80)]
+    hp = IndicatorHyperparams(sma_period=29)
+
+    training.walk_forward_backtest(data, 20, 20, indicator_hp=hp, freeze_features=True)
+    assert periods[0] == 29
+    assert periods[1] == 29

--- a/tests/test_meta_freeze.py
+++ b/tests/test_meta_freeze.py
@@ -1,0 +1,19 @@
+
+import artibot.rl as rl
+from artibot.hyperparams import HyperParams, IndicatorHyperparams
+from artibot.ensemble import EnsembleModel
+import torch
+
+
+class DummyEnsemble:
+    def __init__(self):
+        self.hp = HyperParams(indicator_hp=IndicatorHyperparams(), freeze_features=True)
+        self.device = torch.device("cpu")
+        self.optimizers = []
+
+
+def test_meta_freeze(monkeypatch):
+    ens = DummyEnsemble()
+    agent = rl.MetaTransformerRL(ens)
+    act, _, _ = agent.pick_action([0.0] * agent.state_dim)
+    assert not any(k.startswith("toggle_") or k.endswith("_period_delta") for k in act)


### PR DESCRIPTION
## Summary
- add configurable `WARMUP_STEPS` constant
- expose `freeze_features` hyperparameter and respect it in RL agent
- propagate tuned indicator parameters to all ensemble constructors
- reset meta policy state between folds
- improve indicator logging and fold reporting
- document freeze_features flag in README
- add tests for indicator flow and RL freeze behaviour

## Testing
- `pre-commit run --all-files`
- `NO_HEAVY=1 pytest tests/test_meta_freeze.py tests/test_indicator_flow.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6884d3c1f2ec8324af869ac5850fc0cb