### PR TITLE
Add HMM based volatility regime detection

### DIFF
--- a/artibot/environment.py
+++ b/artibot/environment.py
@@ -175,6 +175,7 @@ def install_dependencies() -> None:
         "transformers": "transformers==4.52.4",  # FinBERT sentiment model
         "schedule": "schedule",  # cron-like job scheduler
         "psutil": "psutil",
+        "hmmlearn": "hmmlearn",
     }
     for import_name, pip_name in pkgs.items():
         try:

--- a/artibot/meta_controller.py
+++ b/artibot/meta_controller.py
@@ -24,7 +24,9 @@ class MetaConfig:
 class MetaTransformerRL:
     """Tiny PPO agent used to tune high level settings."""
 
-    def __init__(self, state_dim: int, action_dim: int, cfg: dict | None = None) -> None:
+    def __init__(
+        self, state_dim: int, action_dim: int, cfg: dict | None = None
+    ) -> None:
         meta = (cfg or {}).get("META", {})
         self.cfg = MetaConfig(
             buffer=meta.get("buffer", 1024),
@@ -87,7 +89,9 @@ class MetaTransformerRL:
         adv = np.zeros_like(deltas)
         gae = 0.0
         for t in range(len(deltas) - 1, -1, -1):
-            gae = deltas[t] + self.cfg.gamma * self.cfg.gae_lambda * (1 - dones[t]) * gae
+            gae = (
+                deltas[t] + self.cfg.gamma * self.cfg.gae_lambda * (1 - dones[t]) * gae
+            )
             adv[t] = gae
         returns = adv + values
 
@@ -108,4 +112,3 @@ class MetaTransformerRL:
         self.writer.add_scalar("meta/value_loss", float(value_loss), self.step)
         self.writer.add_scalar("meta/entropy", float(entropy), self.step)
         self.step += 1
-

--- a/artibot/regime.py
+++ b/artibot/regime.py
@@ -1,0 +1,31 @@
+"""Utilities for market regime detection."""
+
+from __future__ import annotations
+
+import numpy as np
+from hmmlearn.hmm import GaussianHMM
+
+
+def detect_volatility_regime(prices: np.ndarray, n_states: int = 2) -> int:
+    """Infer the current volatility regime using a Gaussian HMM.
+
+    Parameters
+    ----------
+    prices : np.ndarray
+        Sequence of prices (e.g., closing prices) ordered by time.
+    n_states : int, default 2
+        Number of hidden states for the HMM.
+
+    Returns
+    -------
+    int
+        Index of the inferred current regime ``0`` .. ``n_states - 1``.
+    """
+    if prices.size < 2:
+        return 0
+
+    returns = np.diff(np.log(prices)).reshape(-1, 1)
+    model = GaussianHMM(n_components=n_states, covariance_type="full", n_iter=1000)
+    model.fit(returns)
+    states = model.predict(returns)
+    return int(states[-1])

--- a/tests/test_meta_buffer.py
+++ b/tests/test_meta_buffer.py
@@ -7,4 +7,3 @@ def test_replay_buffer_capped():
     for _ in range(10):
         agent.store_transition([0.0, 0.0], 0, 1.0, [0.0, 0.0], False)
     assert len(agent.replay) <= cfg["META"]["buffer"]
-

--- a/tests/test_regime.py
+++ b/tests/test_regime.py
@@ -1,0 +1,29 @@
+import types
+import sys
+
+import numpy as np
+
+
+def test_detect_volatility_regime(monkeypatch):
+    monkeypatch.setenv("ARTIBOT_SKIP_INSTALL", "1")
+
+    class DummyHMM:
+        def __init__(self, *a, **k):
+            pass
+
+        def fit(self, X):
+            self.X = X
+
+        def predict(self, X):
+            return np.zeros(len(X), dtype=int)
+
+    hmm_mod = types.ModuleType("hmmlearn.hmm")
+    hmm_mod.GaussianHMM = DummyHMM
+    sys.modules.setdefault("hmmlearn", types.ModuleType("hmmlearn"))
+    sys.modules["hmmlearn.hmm"] = hmm_mod
+
+    from artibot.regime import detect_volatility_regime
+
+    prices = np.linspace(1, 10, 10)
+    regime = detect_volatility_regime(prices)
+    assert regime == 0


### PR DESCRIPTION
## Summary
- add `detect_volatility_regime` for Hidden Markov Model regime detection
- install `hmmlearn` via the environment helper
- tests for new regime detection function
- format files with Black

## Testing
- `pre-commit run --all-files`
- `pytest -q tests/test_regime.py`

------
https://chatgpt.com/codex/tasks/task_e_688815c783088324afa67352fb1c9b41