### PR TITLE
Add K-Means market regime detector

### DIFF
--- a/tests/test_regime.py
+++ b/tests/test_regime.py
@@ -22,8 +22,53 @@ def test_detect_volatility_regime(monkeypatch):
     sys.modules.setdefault("hmmlearn", types.ModuleType("hmmlearn"))
     sys.modules["hmmlearn.hmm"] = hmm_mod
 
+    class DummyKMeans:
+        def __init__(self, *a, **k):
+            pass
+
+        def fit(self, X):
+            self.X = X
+
+        def predict(self, X):
+            return np.array([0])
+
+    cluster_mod = types.ModuleType("sklearn.cluster")
+    cluster_mod.KMeans = DummyKMeans
+    sys.modules.setdefault("sklearn", types.ModuleType("sklearn"))
+    sys.modules["sklearn.cluster"] = cluster_mod
+
     from artibot.regime import detect_volatility_regime
 
     prices = np.linspace(1, 10, 10)
     regime = detect_volatility_regime(prices)
     assert regime == 0
+
+
+def test_classify_market_regime(monkeypatch):
+    monkeypatch.setenv("ARTIBOT_SKIP_INSTALL", "1")
+
+    class DummyKMeans:
+        def __init__(self, *a, **k):
+            pass
+
+        def fit(self, X):
+            self.X = X
+
+        def predict(self, X):
+            return np.array([1])
+
+    cluster_mod = types.ModuleType("sklearn.cluster")
+    cluster_mod.KMeans = DummyKMeans
+    sys.modules.setdefault("sklearn", types.ModuleType("sklearn"))
+    sys.modules["sklearn.cluster"] = cluster_mod
+
+    import importlib
+    import artibot.regime as regime
+
+    importlib.reload(regime)
+    regime.KMeans = DummyKMeans
+    classify_market_regime = regime.classify_market_regime
+
+    prices = np.linspace(1.0, 10.0, 200)
+    label = classify_market_regime(prices)
+    assert label == 1


### PR DESCRIPTION
## Summary
- add clustering based regime classification function
- stub sklearn in tests
- cover new logic with unit tests

## Testing
- `pre-commit run --all-files`
- `pytest -q --no-heavy tests/test_regime.py`

------
https://chatgpt.com/codex/tasks/task_e_6888a0ca35248324942bea7fe8f3b4ca