### PR TITLE
Add regime gating

### DIFF
--- a/artibot/globals.py
+++ b/artibot/globals.py
@@ -236,6 +236,9 @@ live_sharpe_history = collections.deque(maxlen=1000)  # GUI plot cache
 live_drawdown_history = collections.deque(maxlen=1000)
 trading_paused = False  # hot pause flag
 
+# Current market regime label used for ensemble gating
+current_regime: int | None = None
+
 # When ``True`` orders are routed to the Phemex testnet
 use_sandbox = True  # True for testnet
 


### PR DESCRIPTION
## Summary
- use regime info to weight EnsembleModel predictions
- store current regime label in globals

## Testing
- `pre-commit run --all-files`
- `pytest tests/test_regime.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tensorboard')*

------
https://chatgpt.com/codex/tasks/task_e_6888a6128a0c8324ab4fc13718b61eb1