### PR TITLE
Implement regime-aware trade gating

### DIFF
--- a/artibot/position.py
+++ b/artibot/position.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import time
 from dataclasses import dataclass
 from typing import Optional, TYPE_CHECKING
+import logging
 
 import artibot.globals as G
 
@@ -44,6 +45,10 @@ class HedgeBook:
         return int(usd / price)
 
     def open_long(self, connector: "PhemexConnector", price: float, hp) -> None:
+        if hasattr(G, "current_regime") and G.current_regime == 1:
+            logging.info("Regime is high-volatility, skipping opening long position.")
+            self.close_long(connector, price)
+            return
         if hp.long_frac == 0:
             self.close_long(connector, price)
             return
@@ -59,6 +64,10 @@ class HedgeBook:
         )
 
     def open_short(self, connector: "PhemexConnector", price: float, hp) -> None:
+        if hasattr(G, "current_regime") and G.current_regime == 1:
+            logging.info("High-vol regime, skipping opening short position.")
+            self.close_short(connector, price)
+            return
         if hp.short_frac == 0:
             self.close_short(connector, price)
             return

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,9 @@ import contextlib
 from importlib.machinery import ModuleSpec
 import numpy as np
 import pytest
+import sklearn as _sklearn  # ensure real sklearn is loaded for hmmlearn
+
+_ = _sklearn.__version__
 
 sys.modules.setdefault("openai", types.SimpleNamespace())
 
@@ -237,9 +240,17 @@ def pytest_configure(config):
         sk = types.ModuleType("sklearn")
         impute_mod = types.ModuleType("sklearn.impute")
         impute_mod.KNNImputer = object
+        cluster_mod = types.ModuleType("sklearn.cluster")
+        cluster_mod.KMeans = object
+        utils_mod = types.ModuleType("sklearn.utils")
+        utils_mod.check_random_state = lambda seed=None: None
         sk.impute = impute_mod
+        sk.cluster = cluster_mod
+        sk.utils = utils_mod
         sys.modules["sklearn"] = sk
         sys.modules["sklearn.impute"] = impute_mod
+        sys.modules["sklearn.cluster"] = cluster_mod
+        sys.modules["sklearn.utils"] = utils_mod
 
     if "optuna" not in sys.modules:
         optuna = types.ModuleType("optuna")

--- a/tests/test_hedge_book.py
+++ b/tests/test_hedge_book.py
@@ -21,3 +21,17 @@ def test_open_long_and_short():
     hb.open_short(conn, 100.0, hp)
     assert hb.long_leg is not None
     assert hb.short_leg is not None
+
+
+def test_skip_trades_in_high_vol_regime():
+    hb = HedgeBook()
+    conn = DummyConn()
+    G.live_equity = 1000.0
+    G.current_regime = 1
+    hp = types.SimpleNamespace(long_frac=0.05, short_frac=0.05)
+    hb.open_long(conn, 100.0, hp)
+    hb.open_short(conn, 100.0, hp)
+    assert hb.long_leg is None
+    assert hb.short_leg is None
+    assert conn.orders == []
+    G.current_regime = None


### PR DESCRIPTION
## Summary
- avoid opening new legs when high-volatility regime is active
- test HedgeBook regime gating
- extend sklearn stub so `hmmlearn` loads under `--no-heavy`

## Testing
- `pre-commit run --all-files`
- `pytest tests/test_hedge_book.py -q --no-heavy`

------
https://chatgpt.com/codex/tasks/task_e_6888ad7b6e7483249a11e34e270daa32