### PR TITLE
Add regime-conditioned strategy caching

### DIFF
--- a/artibot/ensemble.py
+++ b/artibot/ensemble.py
@@ -513,6 +513,14 @@ class EnsembleModel(nn.Module):
         # --- ❹  Push to globals & ping GUI ------------------------------------------
         if not ignore_result:
             G.push_backtest_metrics(current_result)
+            regime = getattr(G, "current_regime", None)
+            if regime is not None:
+                try:
+                    from artibot import regime_cache
+
+                    regime_cache.save_best_for_regime(regime, self, current_result)
+                except Exception as e:  # pragma: no cover - cache failures non-critical
+                    logging.error(f"Regime caching failed: {e}")
         # ---------------- END merged block ----------------
 
         if data_full:

--- a/artibot/regime_cache.py
+++ b/artibot/regime_cache.py
@@ -1,0 +1,84 @@
+"""Regime-aware caching utilities for Artibot.
+
+Automatically stores and retrieves the most successful strategy per regime.
+Regime detection is unsupervised (via HMM/KMeans) and caching occurs when
+performance is positive.
+"""
+
+from __future__ import annotations
+
+import os
+import logging
+import torch
+
+from artibot.hyperparams import IndicatorHyperparams
+
+# Directory for cached regime models
+CACHE_DIR = "regime_model_cache"
+os.makedirs(CACHE_DIR, exist_ok=True)
+
+
+def save_best_for_regime(regime: int, ensemble, result: dict) -> None:
+    """Persist the ensemble state for ``regime`` when performance improves."""
+
+    if result.get("net_pct", 0.0) <= 0:
+        return
+
+    regime_dir = os.path.join(CACHE_DIR, f"cluster_{regime}")
+    os.makedirs(regime_dir, exist_ok=True)
+    filepath = os.path.join(regime_dir, "best.pt")
+
+    prev_best = float("-inf")
+    if os.path.isfile(filepath):
+        try:
+            ckpt = torch.load(filepath)
+            prev_best = ckpt.get("best_composite_reward", float("-inf"))
+        except Exception:
+            prev_best = float("-inf")
+
+    new_reward = result.get("composite_reward", 0.0)
+    if new_reward > prev_best:
+        state_dicts = [m.state_dict() for m in ensemble.models]
+        ihp = ensemble.indicator_hparams
+        torch.save(
+            {
+                "best_composite_reward": new_reward,
+                "sharpe": result.get("sharpe", 0.0),
+                "net_pct": result.get("net_pct", 0.0),
+                "state_dicts": state_dicts,
+                "indicator_hparams": ihp and ihp.__dict__,
+            },
+            filepath,
+        )
+        logging.info(
+            "CACHED_STRATEGY regime=%s reward=%.2f net_pct=%.2f",
+            regime,
+            new_reward,
+            result.get("net_pct", 0.0),
+        )
+
+
+def load_best_for_regime(regime: int, ensemble):
+    """Load the cached model for ``regime`` into ``ensemble`` if available."""
+
+    filepath = os.path.join(CACHE_DIR, f"cluster_{regime}", "best.pt")
+    if not os.path.isfile(filepath):
+        return None
+
+    ckpt = torch.load(filepath, map_location=ensemble.device)
+    state_dicts = ckpt["state_dicts"]
+    ihp = ckpt.get("indicator_hparams")
+    if ihp:
+        try:
+            ensemble.indicator_hparams = IndicatorHyperparams(**ihp)
+        except Exception:
+            pass
+
+    for model, sd in zip(ensemble.models, state_dicts):
+        model.load_state_dict(sd, strict=False)
+
+    return {
+        "best_composite_reward": ckpt.get("best_composite_reward", 0.0),
+        "sharpe": ckpt.get("sharpe", 0.0),
+        "net_pct": ckpt.get("net_pct", 0.0),
+    }

--- a/tests/test_regime_retrain.py
+++ b/tests/test_regime_retrain.py
@@ -1,5 +1,4 @@
 import threading
-import types
 import numpy as np
 import torch
 
@@ -23,7 +22,10 @@ def test_regime_retrain_trigger(monkeypatch):
     monkeypatch.setattr("torch.utils.data.random_split", lambda ds, lens: (ds, ds))
     monkeypatch.setattr(
         "artibot.training.compute_indicators",
-        lambda *a, **k: {"scaled": np.zeros((0, 16), dtype=np.float32), "mask": np.ones(16, dtype=bool)},
+        lambda *a, **k: {
+            "scaled": np.zeros((0, 16), dtype=np.float32),
+            "mask": np.ones(16, dtype=bool),
+        },
     )
 
     class DummyDS:
@@ -40,10 +42,16 @@ def test_regime_retrain_trigger(monkeypatch):
 
     # Simulate regime shift persisting for 3 epochs
     states = iter([0, 1, 1, 1])
-    monkeypatch.setattr(training, "detect_volatility_regime", lambda prices: next(states))
+    monkeypatch.setattr(
+        training, "detect_volatility_regime", lambda prices: next(states)
+    )
 
     retrain_calls = {"n": 0}
-    monkeypatch.setattr(training, "quick_fit", lambda *a, **k: retrain_calls.__setitem__("n", retrain_calls["n"] + 1))
+    monkeypatch.setattr(
+        training,
+        "quick_fit",
+        lambda *a, **k: retrain_calls.__setitem__("n", retrain_calls["n"] + 1),
+    )
 
     ens = EnsembleModel(device=torch.device("cpu"), n_models=1)
     monkeypatch.setattr(ens, "load_best_weights", lambda *a, **k: None)


### PR DESCRIPTION
## Summary
- implement `artibot.regime_cache` to store best weights per detected market regime
- call the cache when training finishes an epoch to persist positive results
- minor formatting fixes from pre-commit hooks

## Testing
- `pre-commit run --all-files`
- `pytest tests/test_regime_adjustment.py::test_adjust_for_regime_changes -q`

------
https://chatgpt.com/codex/tasks/task_e_688954c006b08324bbff643ef0fb8ca8