### PR TITLE
Add regime-aware backtest logic

### DIFF
--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -43,7 +43,7 @@ class DummyEnsemble:
             macd_signal=9,
         )
 
-    def vectorized_predict(self, windows_t, batch_size: int = 512):
+    def vectorized_predict(self, windows_t, batch_size: int = 512, regime_labels=None):
         preds = torch.zeros(len(windows_t), dtype=torch.long)
         avg = {
             "sl_multiplier": torch.tensor(1.0),

--- a/tests/test_backtest_io.py
+++ b/tests/test_backtest_io.py
@@ -6,7 +6,7 @@ import artibot.backtest as bt
 class DummyEnsemble:
     device = "cpu"
 
-    def vectorized_predict(self, w, batch_size):
+    def vectorized_predict(self, w, batch_size, regime_labels=None):
         return (
             np.zeros(len(w), dtype=int),
             None,

--- a/tests/test_reward.py
+++ b/tests/test_reward.py
@@ -35,7 +35,7 @@ class DummyEnsemble:
             displacement=26,
         )
 
-    def vectorized_predict(self, windows_t, batch_size=512):
+    def vectorized_predict(self, windows_t, batch_size=512, regime_labels=None):
         preds = np.zeros(len(windows_t), dtype=np.int64)
         import torch
 

--- a/tests/test_reward_metrics.py
+++ b/tests/test_reward_metrics.py
@@ -58,7 +58,7 @@ def test_composite_reward_uses_risk_metrics(monkeypatch):
             self.device = torch.device("cpu")
             self.indicator_hparams = IndicatorHyperparams()
 
-        def vectorized_predict(self, w, batch_size=512):
+        def vectorized_predict(self, w, batch_size=512, regime_labels=None):
             preds = torch.zeros(len(w), dtype=torch.long)
             avg = {
                 "sl_multiplier": torch.tensor(1.0),


### PR DESCRIPTION
## Summary
- switch ensemble prediction to accept regime labels
- cache per-step regime labels inside backtest
- compute per-regime performance statistics
- extend tests to handle new vectorized_predict signature

## Testing
- `pre-commit run --all-files`
- `pytest -k test_robust_backtest_simple -q`

------
https://chatgpt.com/codex/tasks/task_e_6889bf28a1d88324b42410c15ba1ed81