### PR TITLE
Add regime caching docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,19 @@ These vectors are appended to the model’s input **and are updated live** by
 `artibot/feature_ingest.py`, which runs automatically when you start
 `run_artibot.py`.  The job fetches:
 
-* CryptoPanic headlines → FinBERT sentiment (+1 = bullish, -1 = bearish)  
-* Economic-surprise numbers (e.g. CPI) → Z-scores  
+* CryptoPanic headlines → FinBERT sentiment (+1 = bullish, -1 = bearish)
+* Economic-surprise numbers (e.g. CPI) → Z-scores
 * BTC 7-day realised volatility via the bundled CSV plus live Phemex data
+
+## Regime-Specific Strategy Cache
+
+Market conditions are labelled automatically using `detect_volatility_regime()`
+and `classify_market_regime()`. The current label is stored in
+`G.current_regime` with no manual input. When an ensemble produces a positive
+net profit, `regime_cache.save_best_for_regime()` writes the weights under
+`regime_model_cache/`.  Should the same regime return, `load_best_for_regime()`
+restores those weights automatically. Over time the cache evolves into a library
+of specialised models that the bot switches between without user intervention.
 
 ## Installation
 

--- a/docs/regime.md
+++ b/docs/regime.md
@@ -1,0 +1,7 @@
+# Regime-Specific Caching
+
+Artibot detects market regimes without manual labels. The system clusters recent volatility and trend features with a Gaussian HMM and KMeans. `G.current_regime` is updated automatically during training.
+
+When a strategy yields positive returns, `regime_cache.save_best_for_regime()` stores the ensemble weights under `regime_model_cache/`. Later, `load_best_for_regime()` restores the cached model whenever the same regime is detected again. This allows the bot to learn which strategy performs best in each environment and recall it on demand.
+
+No human intervention is required: regime detection, caching triggers and strategy switching all run online inside the training loop. Over time the cache becomes a library of specialised models that the bot selects from dynamically.


### PR DESCRIPTION
## Summary
- document dynamic regime model caching
- include instructions for how the bot switches strategies automatically

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6889c75cb8808324a34563aad34f1730