### PR TITLE
Adaptive regime clustering

### DIFF
--- a/artibot/ensemble.py
+++ b/artibot/ensemble.py
@@ -278,17 +278,15 @@ class EnsembleModel(nn.Module):
             model.score_history = []
             model.sharpe_ema = 0.0
 
-        for i, model in enumerate(self.models):
-            if i == 0:
-                model.strategy_name = "trend_following"
-            elif i == 1:
-                model.strategy_name = "mean_reversion"
-            elif i == 2:
-                model.strategy_name = "volatility_adaptive"
-            else:
-                model.strategy_name = f"strategy_{i}"
+        if len(self.models) == 3:
+            names = ["trend_following", "mean_reversion", "volatility_adaptive"]
+            for i, model in enumerate(self.models):
+                model.strategy_name = names[i]
+        else:
+            for i, model in enumerate(self.models):
+                model.strategy_name = f"regime_{i}"
 
-        if len(self.models) >= 3:
+        if len(self.models) == 3:
             from copy import deepcopy
 
             base_hp = self._indicator_hparams


### PR DESCRIPTION
## Summary
- upgrade regime classification to choose cluster count via silhouette score and reuse fitted model
- name ensemble strategies dynamically and set specialized indicators only when 3 models are used
- pre-train each model on its regime subset during training
- backtest with regime-aware clustering, track transitions and performance per regime

## Testing
- `ruff check artibot/regime.py artibot/ensemble.py artibot/training.py artibot/backtest.py`
- `pre-commit run --files artibot/regime.py artibot/ensemble.py artibot/training.py artibot/backtest.py`
- `pytest tests/test_smoke.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688ab00b80248324a3ef97d11d6504b1