### PR TITLE
Enable adaptive regime sizing

### DIFF
--- a/artibot/backtest.py
+++ b/artibot/backtest.py
@@ -208,7 +208,8 @@ def robust_backtest(
     *,
     indicator_hp=None,
     dynamic_indicators: bool = False,
-):
+    cluster_count: int | None = None,
+) -> dict:
     """Run a simplified backtest and return key metrics.
 
     Parameters
@@ -223,6 +224,9 @@ def robust_backtest(
     indicator_hp:
         ``IndicatorHyperparams`` instance overriding ``ensemble.indicator_hparams``.
         When ``None`` (default) the ensemble's stored settings are used.
+    cluster_count:
+        Explicit number of market regimes. When ``None`` the ensemble size
+        determines the count.
     """
     # Ensure ``data_full`` is a NumPy array for shape checks
     if isinstance(data_full, list):
@@ -329,7 +333,7 @@ def robust_backtest(
         from artibot.regime import classify_market_regime_batch
 
         num_models = len(getattr(ensemble, "models", []))
-        n_clust = num_models if num_models > 1 else 1
+        n_clust = cluster_count or (num_models if num_models > 1 else 1)
         regimes = classify_market_regime_batch(prices, n_clusters=n_clust)
     except Exception:
         regimes = [0] * len(prices)


### PR DESCRIPTION
## Summary
- detect number of regimes using `classify_market_regime_batch`
- size `EnsembleModel` with this count
- propagate regime count to `robust_backtest`
- apply to validation and walk-forward optimisation

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_688bfcbe54a08324ada31e1328854180