### PR TITLE
Add regime probability blending

### DIFF
--- a/artibot/globals.py
+++ b/artibot/globals.py
@@ -238,6 +238,10 @@ trading_paused = False  # hot pause flag
 
 # Current market regime label used for ensemble gating
 current_regime: int | None = None
+# Most recent regime probability vector
+global_current_regime_prob: list | None = None
+# History of regime probability vectors
+global_regime_prob_history: list = []
 
 # When ``True`` orders are routed to the Phemex testnet
 use_sandbox = True  # True for testnet


### PR DESCRIPTION
## Summary
- allow `predict` to hard-switch or blend based on regime probabilities
- extend `vectorized_predict` with soft regime probabilities
- track selected regime probabilities in globals

## Testing
- `pre-commit run --files artibot/ensemble.py artibot/globals.py`
- `pytest -q` *(fails: ModuleNotFoundError: 'tensorboard')*

------
https://chatgpt.com/codex/tasks/task_e_688d344d34648324842cfdd5d8427e14